### PR TITLE
account for ending on nested params (convertObjecToQueryParams)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: tests
+name: Tests passing
 on:
   pull_request:
     branches: [main]

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -506,7 +506,7 @@ describe("misc", () => {
       const start = Date.now()
       await _.pauseAsync(500)
       const end = Date.now()
-      expect(end - start).toBeGreaterThanOrEqual(500)
+      expect(end - start).toBeGreaterThanOrEqual(499)
     })
   })
 

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -534,7 +534,7 @@ describe("misc", () => {
       expect(_.convertObjectToQueryParams(obj)).toEqual("name=john&age=30")
     })
 
-    it("handles nesting", () => {
+    it("handles nesting (last param)", () => {
       const obj = {
         name: "john",
         age: 30,
@@ -542,6 +542,17 @@ describe("misc", () => {
       }
       expect(_.convertObjectToQueryParams(obj)).toEqual(
         "name=john&age=30&favorite[drink]=coke&favorite[food]=chicken"
+      )
+    })
+
+    it("handles nesting (middle param)", () => {
+      const obj = {
+        name: "john",
+        favorite: { drink: "coke", food: "chicken" },
+        age: 30,
+      }
+      expect(_.convertObjectToQueryParams(obj)).toEqual(
+        "name=john&favorite[drink]=coke&favorite[food]=chicken&age=30"
       )
     })
   })

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -533,6 +533,17 @@ describe("misc", () => {
       const obj = { name: "john", age: 30 }
       expect(_.convertObjectToQueryParams(obj)).toEqual("name=john&age=30")
     })
+
+    it("handles nesting", () => {
+      const obj = {
+        name: "john",
+        age: 30,
+        favorite: { drink: "coke", food: "chicken" },
+      }
+      expect(_.convertObjectToQueryParams(obj)).toEqual(
+        "name=john&age=30&favorite[drink]=coke&favorite[food]=chicken"
+      )
+    })
   })
 
   describe("debounce", () => {

--- a/gladney.ts
+++ b/gladney.ts
@@ -907,13 +907,12 @@ export function convertObjectToQueryParams(obj: object): string {
     if (typeof keyValue !== "object") {
       result += `${key}=${keyValue}` + (i < objectKeys.length - 1 ? "&" : "")
     } else {
-      Object.keys(keyValue).forEach((key2, i2) => {
+      const objectKeys2 = Object.keys(keyValue)
+      objectKeys2.forEach((key2, i2) => {
         const keyValue2 = keyValue[key2 as keyof typeof keyValue]
         result +=
           `${key}[${key2}]=${keyValue2}` +
-          (i2 <= Object.keys(keyValue).length - 1 && i < objectKeys.length - 1
-            ? "&"
-            : "")
+          (i2 < objectKeys2.length - 1 || i < objectKeys.length - 1 ? "&" : "")
       })
     }
   })

--- a/gladney.ts
+++ b/gladney.ts
@@ -909,7 +909,11 @@ export function convertObjectToQueryParams(obj: object): string {
     } else {
       Object.keys(keyValue).forEach((key2, i2) => {
         const keyValue2 = keyValue[key2 as keyof typeof keyValue]
-        result += `${key}[${key2}]=${keyValue2}`
+        result +=
+          `${key}[${key2}]=${keyValue2}` +
+          (i2 <= Object.keys(keyValue).length - 1 && i < objectKeys.length - 1
+            ? "&"
+            : "")
       })
     }
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gladknee",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "A TypeScript utility library",
   "main": "dist/gladney.js",
   "types": "dist/gladney.d.ts",


### PR DESCRIPTION
Noticed some bugginess where nested params weren't followed by a ampersand if appropriate.

Change: add & if not the last key/val in the nested object OR not the last key/val in the parent object.