### PR TITLE
use safeSort inside sortByKeyValues

### DIFF
--- a/gladney.ts
+++ b/gladney.ts
@@ -1236,7 +1236,7 @@ export function sortByKeyValues<T extends object, U extends keyof T>(
     return sortByKeyValue(objs, keys[0], order ? order[0] : undefined)
 
   const groupedByKey = groupByKeyValue(objs, keys[0])
-  const sortedKeyValues = Object.keys(groupedByKey).sort()
+  const sortedKeyValues = safeSort(Object.keys(groupedByKey))
 
   if (order && order[0] === "desc") sortedKeyValues.reverse()
 

--- a/gladney.ts
+++ b/gladney.ts
@@ -772,9 +772,8 @@ type StringOrNumberArray = (string | number)[]
  *
  */
 export function safeSort(arr: StringOrNumberArray) {
-  const isNumberish = (str: string | number) => !isNaN(Number(str))
   return [...arr].sort((a, b) => {
-    if (isNumberish(a)) return Number(a) - Number(b)
+    if (isNumeric(a)) return Number(a) - Number(b)
     else return a < b ? -1 : 1
   })
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gladknee",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "A TypeScript utility library",
   "main": "dist/gladney.js",
   "types": "dist/gladney.d.ts",


### PR DESCRIPTION
This PR replaces `.sort()` inside the `sortByKeyValues()` method with `safeSort()` in order to account for the possibility of numbers as strings for key values.

It also replaces the locally declared `isNumberish()` in `safeSort()` with the `isNumeric()` function.