### PR TITLE
Updates from Ecuador Jan 2024

### DIFF
--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -59,9 +59,6 @@ describe("time & dates", () => {
   describe("getAmountOfTimeFromSeconds", () => {
     it("returns the correct TimeOutput", () => {
       const timeObject = _.getAmountOfTimeFromSeconds(200000)
-      expect(timeObject.years).toEqual(0)
-      expect(timeObject.months).toEqual(0)
-      expect(timeObject.weeks).toEqual(0)
       expect(timeObject.days).toEqual(2)
       expect(timeObject.hours).toEqual(7)
       expect(timeObject.minutes).toEqual(33)
@@ -1139,12 +1136,12 @@ describe("misc", () => {
       expect(_.hexToRgb("#FF0000")).toEqual([255, 0, 0])
     })
   })
-})
 
-describe("stripHTML", () => {
-  it("removes any html tags from text", () => {
-    expect(_.stripHTML("<html><p>Hello <b>world</b>!</p></html>")).toBe(
-      "Hello world!"
-    )
+  describe("stripHTML", () => {
+    it("removes any html tags from text", () => {
+      expect(_.stripHTML("<html><p>Hello <b>world</b>!</p></html>")).toBe(
+        "Hello world!"
+      )
+    })
   })
 })

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -430,6 +430,27 @@ describe("arrays", () => {
     })
   })
 
+  describe("getCallbackResultCounts", () => {
+    it("returns the counts of results", () => {
+      const objs = [
+        { a: 1, b: 1 },
+        { a: 1, b: 1 },
+        { a: 2, b: 1 },
+        { a: 1, b: 1 },
+        { a: 2, b: 2 },
+        { a: 3, b: 1 },
+      ]
+
+      const aPlusB = ({ a, b }: { a: number; b: number }) => a + b
+
+      expect(_.getCallbackResultCounts(objs, aPlusB)).toEqual({
+        "2": 3,
+        "3": 1,
+        "4": 2,
+      })
+    })
+  })
+
   describe("flatten", () => {
     it("returns a three dimensional array flattened to a one dimensional array", () => {
       expect(

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -138,6 +138,31 @@ describe("time & dates", () => {
   })
 })
 
+describe("getRelativeTimeDiff", () => {
+  it("returns the correct durations", () => {
+    const secondsInAMinute = 60
+    const secondsInAnHour = 3600
+    const secondsInADay = 86400
+    const secondsInAWeek = 604800
+    const secondsInAMonth = 2592000 // Assumes 30 day month
+    const secondsInAYear = 31557600
+
+    const oneDayAgo = new Date(Date.now() - secondsInADay * 1000)
+    const twoWeeksAgo = new Date(Date.now() - secondsInAWeek * 1000 * 2)
+    const threeMonthsAgo = new Date(Date.now() - secondsInAMonth * 1000 * 3)
+    const fourYearsAgo = new Date(Date.now() - secondsInAYear * 1000 * 4)
+    const fiveMinutesAgo = new Date(Date.now() - secondsInAMinute * 1000 * 5)
+    const sixHoursAgo = new Date(Date.now() - secondsInAnHour * 1000 * 6)
+
+    expect(_.getRelativeTimeDiff(oneDayAgo)).toBe("yesterday")
+    expect(_.getRelativeTimeDiff(twoWeeksAgo)).toBe("2 weeks ago")
+    expect(_.getRelativeTimeDiff(threeMonthsAgo)).toBe("3 months ago")
+    expect(_.getRelativeTimeDiff(fourYearsAgo)).toBe("4 years ago")
+    expect(_.getRelativeTimeDiff(fiveMinutesAgo)).toBe("5 minutes ago")
+    expect(_.getRelativeTimeDiff(sixHoursAgo)).toBe("6 hours ago")
+  })
+})
+
 describe("isPast", () => {
   it("returns true if the date has passed", () => {
     expect(_.isPast(new Date("01-01-1979"))).toBe(true)

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -975,6 +975,7 @@ describe("misc", () => {
       const double = (n: number) => n * 2
       const triple = (n: number) => n * 3
       const doubleThenTriple = _.pipe(double, triple)
+
       expect(doubleThenTriple(3)).toEqual(18)
     })
   })

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -133,40 +133,58 @@ describe("time & dates", () => {
       expect(testDate.getSeconds()).toBe(59)
     })
   })
-})
 
-describe("getRelativeTimeDiff", () => {
-  it("returns the correct durations", () => {
-    const secondsInAMinute = 60
-    const secondsInAnHour = 3600
-    const secondsInADay = 86400
-    const secondsInAWeek = 604800
-    const secondsInAMonth = 2592000 // Assumes 30 day month
-    const secondsInAYear = 31557600
+  describe("getTimeDiff", () => {
+    it("returns the correct duration", () => {
+      const start = new Date()
+      const end = new Date(start)
+      end.setDate(end.getDate() - 11)
+      end.setHours(end.getHours() - 2)
+      end.setMinutes(end.getMinutes() - 5)
+      end.setSeconds(end.getSeconds() - 43)
 
-    const oneDayAgo = new Date(Date.now() - secondsInADay * 1000)
-    const twoWeeksAgo = new Date(Date.now() - secondsInAWeek * 1000 * 2)
-    const threeMonthsAgo = new Date(Date.now() - secondsInAMonth * 1000 * 3)
-    const fourYearsAgo = new Date(Date.now() - secondsInAYear * 1000 * 4)
-    const fiveMinutesAgo = new Date(Date.now() - secondsInAMinute * 1000 * 5)
-    const sixHoursAgo = new Date(Date.now() - secondsInAnHour * 1000 * 6)
-
-    expect(_.getRelativeTimeDiff(oneDayAgo)).toBe("yesterday")
-    expect(_.getRelativeTimeDiff(twoWeeksAgo)).toBe("2 weeks ago")
-    expect(_.getRelativeTimeDiff(threeMonthsAgo)).toBe("3 months ago")
-    expect(_.getRelativeTimeDiff(fourYearsAgo)).toBe("4 years ago")
-    expect(_.getRelativeTimeDiff(fiveMinutesAgo)).toBe("5 minutes ago")
-    expect(_.getRelativeTimeDiff(sixHoursAgo)).toBe("6 hours ago")
-  })
-})
-
-describe("isPast", () => {
-  it("returns true if the date has passed", () => {
-    expect(_.isPast(new Date("01-01-1979"))).toBe(true)
+      expect(_.getTimeDiff(start, end)).toEqual({
+        days: 11,
+        hours: 2,
+        minutes: 5,
+        seconds: 43,
+      })
+    })
   })
 
-  it("returns false if the date has not passed", () => {
-    expect(_.isPast(new Date("01-01-3000"))).toBe(false)
+  describe("getRelativeTimeDiff", () => {
+    it("returns the correct relative duration", () => {
+      const secondsInAMinute = 60
+      const secondsInAnHour = 3600
+      const secondsInADay = 86400
+      const secondsInAWeek = 604800
+      const secondsInAMonth = 2592000 // Assumes 30 day month
+      const secondsInAYear = 31557600
+
+      const oneDayAgo = new Date(Date.now() - secondsInADay * 1000)
+      const twoWeeksAgo = new Date(Date.now() - secondsInAWeek * 1000 * 2)
+      const threeMonthsAgo = new Date(Date.now() - secondsInAMonth * 1000 * 3)
+      const fourYearsAgo = new Date(Date.now() - secondsInAYear * 1000 * 4)
+      const fiveMinutesAgo = new Date(Date.now() - secondsInAMinute * 1000 * 5)
+      const sixHoursAgo = new Date(Date.now() - secondsInAnHour * 1000 * 6)
+
+      expect(_.getRelativeTimeDiff(oneDayAgo)).toBe("yesterday")
+      expect(_.getRelativeTimeDiff(twoWeeksAgo)).toBe("2 weeks ago")
+      expect(_.getRelativeTimeDiff(threeMonthsAgo)).toBe("3 months ago")
+      expect(_.getRelativeTimeDiff(fourYearsAgo)).toBe("4 years ago")
+      expect(_.getRelativeTimeDiff(fiveMinutesAgo)).toBe("5 minutes ago")
+      expect(_.getRelativeTimeDiff(sixHoursAgo)).toBe("6 hours ago")
+    })
+  })
+
+  describe("isPast", () => {
+    it("returns true if the date has passed", () => {
+      expect(_.isPast(new Date("01-01-1979"))).toBe(true)
+    })
+
+    it("returns false if the date has not passed", () => {
+      expect(_.isPast(new Date("01-01-3000"))).toBe(false)
+    })
   })
 })
 

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -297,11 +297,17 @@ describe("arrays", () => {
     })
   })
 
-  describe("getRandomItem", () => {
+  describe("getRandomItems", () => {
     it("gets a random item from the array", () => {
       const arr = [1, 2, 3, 4, 5]
-      const randomItem = _.getRandomItem(arr)
+      const [randomItem] = _.getRandomItems(arr, 1)
       expect(arr.includes(randomItem)).toBe(true)
+    })
+
+    it("does not get the same item twice", () => {
+      const arr = [1, 2, 3, 4, 5]
+      const set = new Set(_.getRandomItems(arr, 5) as number[])
+      expect(_.isEqual(Array.from(set).sort(), arr)).toBe(true)
     })
   })
 

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -250,8 +250,8 @@ describe("slugify", () => {
     expect(_.slugify(" this is some text ")).toBe("this-is-some-text")
   })
 
-  it("removes non-letter characters", () => {
-    expect(_.slugify("this is some text!")).toBe("this-is-some-text")
+  it("removes non-letter and non-number characters", () => {
+    expect(_.slugify("42 things you can do")).toBe("42-things-you-can-do")
   })
 
   it("can use a custom separator", () => {

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -1029,6 +1029,15 @@ describe("misc", () => {
     })
   })
 
+  describe("curry", () => {
+    it("creates a curried version of a function", () => {
+      const addThreeNumbers = (n1: number, n2: number, n3: number) =>
+        n1 + n2 + n3
+      const curriedAdd3 = _.curry(addThreeNumbers)
+      expect(curriedAdd3(1)(2)(3)).toBe(6)
+    })
+  })
+
   describe("debounce", () => {
     it("immediate = true. invokes the function immediately on first call", () => {
       const func = jest.fn()

--- a/gladney.ts
+++ b/gladney.ts
@@ -181,39 +181,22 @@ export function mode(...numbers: (number | number[])[]) {
 }
 
 export interface TimeObject {
-  years: number
-  months: number
-  weeks: number
   days: number
   hours: number
   minutes: number
   seconds: number
-  inYears: () => number
-  inMonths: () => number
-  inWeeks: () => number
-  inDays: () => number
-  inHours: () => number
-  inMinutes: () => number
-  inSeconds: () => number
 }
 
 const secondsInAMinute = 60
 const secondsInAnHour = 3600
 const secondsInADay = 86400
-const secondsInAWeek = 604800
-const secondsInAMonth = 2592000 // Assumes 30 day month
-const secondsInAYear = 31557600
 
-/** Returns a `TimeObject` with calculated years, months, weeks, days, hours, minutes and seconds from an amount of 
- * seconds. A `TimeObject` also includes methods to measure the amount of time in a specific unit (i.e. minutes)
+/** Returns a `TimeObject` with calculated days, hours, minutes and seconds from an amount of seconds.
  *
  * _Example:_
  * ```typescript
  * getAmountOfTimeFromSeconds(2000000)
-//=> { years: 0, months: 0, weeks: 3, days: 2, hours: 3, minutes: 33, seconds: 20 }
-
-* getAmountOfTimeFromSeconds(2000000).inMinutes()
-//=> 33333.333333333336
+//=> { days: 23, hours: 3, minutes: 33, seconds: 20 }
 
 interface TimeObject {
   years: number
@@ -235,20 +218,10 @@ interface TimeObject {
  **/
 export function getAmountOfTimeFromSeconds(seconds: number): TimeObject {
   return {
-    years: Math.floor(seconds / secondsInAYear),
-    months: Math.floor((seconds % secondsInAYear) / secondsInAMonth),
-    weeks: Math.floor((seconds % secondsInAMonth) / secondsInAWeek),
-    days: Math.floor((seconds % secondsInAWeek) / secondsInADay),
+    days: Math.floor(seconds / secondsInADay),
     hours: Math.floor((seconds % secondsInADay) / secondsInAnHour),
     minutes: Math.floor((seconds % secondsInAnHour) / secondsInAMinute),
     seconds: seconds % secondsInAMinute,
-    inYears: () => seconds / secondsInAYear,
-    inMonths: () => seconds / secondsInAMonth,
-    inWeeks: () => seconds / secondsInAWeek,
-    inDays: () => seconds / secondsInADay,
-    inHours: () => seconds / secondsInAnHour,
-    inMinutes: () => seconds / secondsInAMinute,
-    inSeconds: () => seconds,
   }
 }
 
@@ -256,20 +229,10 @@ export function getAmountOfTimeFromSeconds(seconds: number): TimeObject {
  * a specific date. A `TimeObject` also includes methods to measure the amount of time in a specific unit (i.e. minutes)
  * ```typescript
 interface TimeObject {
-  years: number
-  months: number
-  weeks: number
   days: number
   hours: number
   minutes: number
   seconds: number
-  inYears: () => number
-  inMonths: () => number
-  inWeeks: () => number
-  inDays: () => number
-  inHours: () => number
-  inMinutes: () => number
-  inSeconds: () => number
 }
  * ```
  **/
@@ -284,20 +247,10 @@ export function timeUntil(date: Date): TimeObject {
  * specific date. A `TimeObject` also includes methods to measure the amount of time in a specific unit (i.e. minutes)
  * ```typescript
 interface TimeObject {
-  years: number
-  months: number
-  weeks: number
   days: number
   hours: number
   minutes: number
   seconds: number
-  inYears: () => number
-  inMonths: () => number
-  inWeeks: () => number
-  inDays: () => number
-  inHours: () => number
-  inMinutes: () => number
-  inSeconds: () => number
 }
  * ```
  **/
@@ -350,6 +303,11 @@ export function isPast(date: Date) {
   return new Date(date).getTime() < Date.now()
 }
 
+export function getTimeDiff(fromDate: Date, toDate: Date) {
+  const diff = (toDate.getTime() - fromDate.getTime()) / 1000
+  return getAmountOfTimeFromSeconds(diff)
+}
+
 /** Returns the relative time difference of two dates
  *
  * Example:
@@ -357,7 +315,7 @@ export function isPast(date: Date) {
  * ```typescript
  * const fiveMinutesAgo = new Date(Date.now() - 60 * 1000 * 5)
  *
- * getRelativeTimeDiff(fiveMinutesAgo) //=> "5 minutes ago"
+ * getRelativeTime(fiveMinutesAgo) //=> "5 minutes ago"
  * ```
  */
 export function getRelativeTimeDiff(toDate: Date, fromDate: Date = new Date()) {
@@ -366,7 +324,7 @@ export function getRelativeTimeDiff(toDate: Date, fromDate: Date = new Date()) {
     { n: 60, unit: "minutes" },
     { n: 24, unit: "hours" },
     { n: 7, unit: "days" },
-    { n: 4, unit: "weeks" },
+    { n: 4.34524, unit: "weeks" },
     { n: 12, unit: "months" },
     { n: Number.POSITIVE_INFINITY, unit: "years" },
   ]

--- a/gladney.ts
+++ b/gladney.ts
@@ -1007,6 +1007,21 @@ export function getSharedItems<T>(...arrs: T[][]) {
   return result
 }
 
+/** Returns the provided array with two items' positions swapped
+ *
+ * Example:
+ * ```typescript
+ * swapItems([0, 1, 2, 3, 4], 1, 3) //=> [0, 3, 2, 1, 4]
+ * ```
+ */
+export function swapItems<T>(arr: T[], index1: number, index2: number) {
+  return arr.map((item, i) => {
+    if (i === index1) return arr[index2]
+    if (i === index2) return arr[index1]
+    return item
+  })
+}
+
 /** Returns a boolean of whether or not two arrays or two objects have the same items or key value pairs respectively. You can 
  optionally pass in a boolean to require that the order of the items matches for arrays (default: false) and a boolean to 
  apply case sensitivity (default: false).
@@ -1031,23 +1046,6 @@ export function getSharedItems<T>(...arrs: T[][]) {
  * 
  * NOTE: `orderMatters` is false by default.
  **/
-
-/** Returns the provided array with two items' positions swapped
- *
- * Example:
- * ```typescript
- * swapItems([0, 1, 2, 3, 4], 1, 3) //=> [0, 3, 2, 1, 4]
- * ```
- */
-
-export function swapItems<T>(arr: T[], index1: number, index2: number) {
-  return arr.map((item, i) => {
-    if (i === index1) return arr[index2]
-    if (i === index2) return arr[index1]
-    return item
-  })
-}
-
 export function isEqual(
   thing1: object | [],
   thing2: object | [],
@@ -1613,7 +1611,6 @@ sortByCallbackResult(socialStats, getPopularity)
 ]
  * ```
  */
-
 export function sortByCallbackResult<T>(things: T[], func: Function) {
   const groupedByResult = groupByCallbackResult(things, func)
   return safeSort(Object.keys(groupedByResult)).reduce(

--- a/gladney.ts
+++ b/gladney.ts
@@ -1718,7 +1718,7 @@ const triple = (n: number) => n * 3
 const doubleThenTriple = pipe(double, triple)
 
 doubleThenTriple(6) //=> 36
-* ```
+```
  **/
 export function pipe<T>(
   ...funcs: [
@@ -1852,6 +1852,18 @@ export function memoize<T extends (...args: any[]) => any>(func: T): T {
 
 type Falsy = null | undefined | false
 
+/** Returns a function with arguments prepended to the arguments it receives.
+ * 
+ * Example:
+ * ```typescript
+const greet = (greeting: string, name: string) => greeting + " " + name;
+const sayHello = partial(greet, "Hello")
+
+sayHello("John") //=> "Hello John"
+}
+
+* ```
+ **/
 export function partial<T extends (...args: any[]) => any>(
   func: T,
   ...args: (Parameters<typeof func>[number] | Falsy)[]

--- a/gladney.ts
+++ b/gladney.ts
@@ -658,7 +658,9 @@ export function isNumeric(n: string | number) {
  * ```
  */
 export function shave<T>(iterable: T[], n: number): T[]
+
 export function shave(iterable: string, n: number): string
+
 export function shave<T>(iterable: string | T[], n: number) {
   return n > 0 ? iterable.slice(0, iterable.length - n) : iterable.slice(n * -1)
 }

--- a/gladney.ts
+++ b/gladney.ts
@@ -496,7 +496,7 @@ export function pad(
   str: string,
   length: number,
   char: string,
-  style: "leading" | "trailing"
+  style: "leading" | "trailing" = "trailing"
 ) {
   if (str.length >= length) return str
 

--- a/gladney.ts
+++ b/gladney.ts
@@ -537,7 +537,7 @@ export function unEscapeString(str: string) {
 
 /** Returns a random string of specified length. Can include letters and/or numbers.
  *
- * NOTE: `includeLetters` and `includeNumbers` both default to true.
+ * NOTE: `includeLetters` and `includeNumbers` both default to true. `includeSpecialChars` defaults to false.
  * 
  * Example:
  * ```typescript
@@ -546,17 +546,22 @@ export function unEscapeString(str: string) {
 getRandomString(5, true, false) //=> "GjOxa"
 
 getRandomString(5, false, true) //=> "39281"
+
+getRandomString(5, true, true, true) //=> "G2a$k!"
  * ```
  **/
 export function getRandomString(
   length: number,
   includeLetters = true,
-  includeNumbers = true
+  includeNumbers = true,
+  includeSpecialChars = false
 ): string {
   const chars =
     (includeLetters
       ? "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-      : "") + (includeNumbers ? "0123456789" : "")
+      : "") +
+    (includeNumbers ? "0123456789" : "") +
+    (includeSpecialChars ? "!@#$%^&*()" : "")
   let randomString = ""
   for (let i = 1; i <= length; i++) {
     randomString += chars[Math.floor(Math.random() * chars.length)]

--- a/gladney.ts
+++ b/gladney.ts
@@ -58,8 +58,8 @@ export function clampNumber(
   max?: number | false
 ) {
   let result = n
-  if (min) result = n > min ? n : min
-  if (max) result = result < max ? result : max
+  if (min !== false) result = n > min ? n : min
+  if (max !== false && max !== undefined) result = result < max ? result : max
   return result
 }
 

--- a/gladney.ts
+++ b/gladney.ts
@@ -75,7 +75,7 @@ export function doubleDigit(n: number) {
   else return String(`0${n}`).slice(-2)
 }
 
-/** Returns an array of numbers, starting from a start number and ending with an end number.
+/** Returns an array of numbers, starting from and ending at provided numbers.
  * You can optionally pass in a step number to increment by a number other than 1. You can also increment negatively.
  *
  * _Example:_

--- a/gladney.ts
+++ b/gladney.ts
@@ -1133,7 +1133,7 @@ export function omitKeys<T extends object, U extends keyof T>(
       result[key as string] = obj[key as U]
     }
   })
-  return result
+  return result as Partial<T>
 }
 
 /** Returns an object with only the specific keys included.
@@ -1156,7 +1156,7 @@ export function pickKeys<T extends object, U extends keyof T>(
       result[key] = obj[key as U]
     }
   })
-  return result
+  return result as Partial<T>
 }
 
 /** Returns a single object with all of the key value pairs from two or more objects.

--- a/gladney.ts
+++ b/gladney.ts
@@ -565,11 +565,14 @@ export function getRandomString(
 }
 
 /**
- * Returns a string with the first letter capitalized. Optionally pass in boolean to convert following characters to lower case.
+ * Returns a string with the first letter of each word capitalized. Optionally pass in
+ * a boolean to convert following characters to lower case.
  *
  * Example:
  * ```typescript
  * capitalize("stephen") //=> "Stephen"
+ *
+ * capitalize("hello world") //=> "Hello World"
  *
  * capitalize("hELLO", true) //=> "Hello"
  *
@@ -577,10 +580,14 @@ export function getRandomString(
  * ```
  */
 export function capitalize(str: string, lowercaseOthers = false) {
-  return (
+  const capitalizeWord = (str: string) =>
     str[0].toUpperCase() +
     (lowercaseOthers ? str.slice(1).toLowerCase() : str.slice(1))
-  )
+
+  return str
+    .split(" ")
+    .map((word) => capitalizeWord(word))
+    .join(" ")
 }
 
 /**

--- a/gladney.ts
+++ b/gladney.ts
@@ -154,7 +154,7 @@ export function mean(...numbers: (number | number[])[]) {
  * ```
  **/
 export function median(...numbers: (number | number[])[]) {
-  const sorted = safeSort(flatten(numbers)) as number[]
+  const sorted = safeSort(flatten(numbers) as number[])
   if (sorted.length % 2 === 0) {
     return mean(sorted[sorted.length / 2], sorted[sorted.length / 2 - 1])
   } else {
@@ -790,7 +790,7 @@ export function chunkArray<T>(arr: T[], chunkSize: number) {
  * flatten([1, [2, 3, [4, 5]], 6], 1)  //=> [1, 2, 3, [4, 5], 6]
  * ```
  **/
-export function flatten(arr: any[], levels = 0): any[] {
+export function flatten(arr: any[], levels = 0): unknown[] {
   function flattenWithAccumulator(
     arr: any[],
     levels = 0,
@@ -826,6 +826,10 @@ type StringOrNumberArray = (string | number)[]
  * ```
  *
  */
+export function safeSort(arr: string[]): string[]
+
+export function safeSort(arr: number[]): number[]
+
 export function safeSort(arr: StringOrNumberArray) {
   return [...arr].sort((a, b) => {
     if (isNumeric(a)) return Number(a) - Number(b)
@@ -835,6 +839,10 @@ export function safeSort(arr: StringOrNumberArray) {
 
 /** Returns an array sorted (ascending) via bubble sort.
  **/
+export function bubbleSort(arr: string[]): string[]
+
+export function bubbleSort(arr: number[]): number[]
+
 export function bubbleSort(arr: StringOrNumberArray) {
   let noSwaps
   const _arr = [...arr]
@@ -855,6 +863,11 @@ export function bubbleSort(arr: StringOrNumberArray) {
 
 /** Returns an array sorted (ascending) via selection sort.
  **/
+
+export function selectionSort(arr: string[]): string[]
+
+export function selectionSort(arr: number[]): number[]
+
 export function selectionSort(arr: StringOrNumberArray) {
   const _arr = [...arr]
   const swap = (arr: unknown[], idx1: number, idx2: number) =>
@@ -875,6 +888,10 @@ export function selectionSort(arr: StringOrNumberArray) {
 
 /** Returns an array sorted (ascending) via insertion sort.
  **/
+export function insertionSort(arr: string[]): string[]
+
+export function insertionSort(arr: number[]): number[]
+
 export function insertionSort(arr: StringOrNumberArray) {
   var currentVal
   const _arr = [...arr]

--- a/gladney.ts
+++ b/gladney.ts
@@ -757,9 +757,9 @@ export function chunkArray<T>(arr: T[], chunkSize: number) {
  *
  * Example:
  * ```typescript
- * flatten([1,[2,3,[4,5]],6]) //=> [1, 2, 3, 4, 5, 6]
+ * flatten([1, [2, 3, [4, 5]], 6])  //=> [1, 2, 3, 4, 5, 6]
  *
- * flatten([1,[2,3,[4,5]],6], 1) //=> [1, 2, 3, [4, 5], 6]
+ * flatten([1, [2, 3, [4, 5]], 6], 1)  //=> [1, 2, 3, [4, 5], 6]
  * ```
  **/
 export function flatten(arr: any[], levels = 0, currentLevel = 0): any[] {

--- a/gladney.ts
+++ b/gladney.ts
@@ -1951,12 +1951,12 @@ type CurryFunction<T> = T extends (...args: infer Args) => infer Result
 export function curry<T extends (...args: any[]) => any>(
   func: T
 ): CurryFunction<T> {
-  function rf(func: Function, i: number, args: any[]): Function {
+  function curried(func: Function, i: number, args: any[]): Function {
     return args.length < func.length
-      ? (arg: any) => rf(func, i - 1, [...args, arg])
+      ? (arg: any) => curried(func, i - 1, [...args, arg])
       : func(...args)
   }
-  return rf(func, func.length, []) as CurryFunction<T>
+  return curried(func, func.length, []) as CurryFunction<T>
 }
 
 /** Prompts a user in their browser to save some specific text to a file on their machine.

--- a/gladney.ts
+++ b/gladney.ts
@@ -445,6 +445,7 @@ export function mask(
       config.style === "leading" ? str : str.split("").reverse().join("")
 
     let maskedCount = 0
+
     const masked = _str.split("").reduce((acc, char) => {
       if (config?.ignore && config.ignore.includes(char)) {
         return acc + char
@@ -456,6 +457,7 @@ export function mask(
         return acc + (config?.maskWith || "*")
       } else return acc + char
     }, "")
+
     return config?.style === "leading"
       ? masked
       : masked.split("").reverse().join("")
@@ -464,10 +466,13 @@ export function mask(
       (str.length - (config.maskLength || str.length)) % 2 === 0
         ? (str.length - (config.maskLength || str.length)) / 2
         : Math.floor((str.length - (config.maskLength || str.length)) / 2)
+
     let maskedCount = 0
+
     return str.split("").reduce((acc, char, i) => {
       const shouldIgnoreCharacter =
         !!config?.ignore && config.ignore.includes(char)
+
       if (shouldIgnoreCharacter) return acc + char
       else if (i + 1 <= length1) return acc + char
       else if (config?.maskLength && maskedCount < config?.maskLength) {

--- a/gladney.ts
+++ b/gladney.ts
@@ -303,8 +303,24 @@ export function isPast(date: Date) {
   return new Date(date).getTime() < Date.now()
 }
 
-export function getTimeDiff(fromDate: Date, toDate: Date) {
-  const diff = (toDate.getTime() - fromDate.getTime()) / 1000
+/** Returns a TimeObject representing the amount of time between two dates.
+ *
+ * Example:
+ *
+ * ```typescript
+ * const fiveMinutesAgo = new Date(Date.now() - 60 * 1000 * 5)
+ *
+ * getTimeDiff(new Date(), fiveMinutesAgo) //=>
+ *  {
+ *    days: 0,
+ *    hours: 0,
+ *    minutes: 5,
+ *    seconds: 0
+ *  }
+ * ```
+ */
+export function getTimeDiff(dateA: Date, dateB: Date) {
+  const diff = Math.abs((dateA.getTime() - dateB.getTime()) / 1000)
   return getAmountOfTimeFromSeconds(diff)
 }
 
@@ -318,7 +334,7 @@ export function getTimeDiff(fromDate: Date, toDate: Date) {
  * getRelativeTime(fiveMinutesAgo) //=> "5 minutes ago"
  * ```
  */
-export function getRelativeTimeDiff(toDate: Date, fromDate: Date = new Date()) {
+export function getRelativeTimeDiff(to: Date, from: Date = new Date()) {
   const TIME_UNITS: { n: number; unit: Intl.RelativeTimeFormatUnit }[] = [
     { n: 60, unit: "seconds" },
     { n: 60, unit: "minutes" },
@@ -329,7 +345,7 @@ export function getRelativeTimeDiff(toDate: Date, fromDate: Date = new Date()) {
     { n: Number.POSITIVE_INFINITY, unit: "years" },
   ]
 
-  let duration = (toDate.getTime() - fromDate.getTime()) / 1000
+  let duration = (to.getTime() - from.getTime()) / 1000
 
   for (let i = 0; i < TIME_UNITS.length; i++) {
     const currentUnit = TIME_UNITS[i]

--- a/gladney.ts
+++ b/gladney.ts
@@ -683,9 +683,29 @@ export function shuffle<T>(array: T[]) {
  * getRandomItem([1, 2, 3, 4, 5, 6]) //=> 3
  * ```
  **/
-export function getRandomItem<T>(arr: T[]) {
+export function getRandomItem<T>(arr: T[], n: number) {
   const randomIndex = Math.floor(Math.random() * arr.length)
   return arr[randomIndex]
+}
+
+/** Returns random elements from an array
+ *
+ * Example:
+ * ```typescript
+ * getRandomItems([1, 2, 3, 4, 5, 6], 1) //=> [3]
+ *
+ * getRandomItems([1, 2, 3, 4, 5, 6], 3) //=> [2, 5, 1]
+ * ```
+ **/
+export function getRandomItems<T>(arr: T[], n: number) {
+  let remainingItems = Array.from(arr)
+  const result = []
+  for (let i = 1; i <= n; i++) {
+    const randomIndex = Math.floor(Math.random() * remainingItems.length)
+    result.push(remainingItems[randomIndex])
+    remainingItems.splice(randomIndex, 1)
+  }
+  return result
 }
 
 /** Returns an array of every Nth item in an array
@@ -753,8 +773,6 @@ export function chunkArray<T>(arr: T[], chunkSize: number) {
 /** Returns a single dimensional array by default. If you pass a number for levels, the function will only reduce
  * that many dimensions of arrays.
  *
- * NOTE: You should never pass in a value for `currentLevel`. This is a helper param used for recursion.
- *
  * Example:
  * ```typescript
  * flatten([1, [2, 3, [4, 5]], 6])  //=> [1, 2, 3, 4, 5, 6]
@@ -762,12 +780,22 @@ export function chunkArray<T>(arr: T[], chunkSize: number) {
  * flatten([1, [2, 3, [4, 5]], 6], 1)  //=> [1, 2, 3, [4, 5], 6]
  * ```
  **/
-export function flatten(arr: any[], levels = 0, currentLevel = 0): any[] {
-  return arr.reduce((acc, item) => {
-    if (Array.isArray(item) && (!levels || currentLevel < levels)) {
-      return [...acc, ...flatten(item, levels, currentLevel + 1)]
-    } else return [...acc, item]
-  }, [])
+export function flatten(arr: any[], levels = 0): any[] {
+  function flattenWithAccumulator(
+    arr: any[],
+    levels = 0,
+    currentLevel = 0
+  ): any[] {
+    return arr.reduce((acc, item) => {
+      if (Array.isArray(item) && (!levels || currentLevel < levels)) {
+        return [
+          ...acc,
+          ...flattenWithAccumulator(item, levels, currentLevel + 1),
+        ]
+      } else return [...acc, item]
+    }, [])
+  }
+  return flattenWithAccumulator(arr, levels)
 }
 
 type StringOrNumberArray = (string | number)[]
@@ -1514,16 +1542,27 @@ export function getKeyWithLargestValue<T extends object>(obj: T) {
  *
  * Example:
  * ```typescript
- * const ages = [{ age: 28 }, { age: 14 }, { age: 67 }, { age: 17 }, ]
- *
- * const canDrinkAlcohol = (obj:{ age: number }) => obj.age >= 21
- *
- * groupByCallbackResult(ages, canDrinkAlcohol)
- * //=>
- *      {
- *        "true": [{ age: 28 }, { age: 67 }]
- *        "false": [{ age: 14 }, { age: 17 }]
- *      }
+ const people = [
+                   { name: "John", age: 28 }, 
+                   { name: "Brittany", age: 14 }, 
+                   { name: "Susan", age: 67 }, 
+                   { name: "Jeff", age: 17 }
+                  ]
+ 
+const canDrinkAlcohol = (person: { age: number }) => person.age >= 21
+ 
+groupByCallbackResult(people, canDrinkAlcohol)
+ //=>
+      {
+       "true": [
+         { name: "John", age: 28 },
+         { name; "Susan", age: 67 }
+       ]
+       "false": [
+         { name: "Brittany", age: 14 },
+         { name: "Jeff", age: 17 }
+       ]
+      }
  * ```
  */
 export function groupByCallbackResult(things: any[], func: Function) {

--- a/gladney.ts
+++ b/gladney.ts
@@ -601,11 +601,11 @@ export function capitalize(str: string, lowercaseOthers = false) {
 }
 
 /**
- * Returns a string lowercased with non letter characters removed and spaces and underscores replaced with a separator (- by default)
+ * Returns a string lowercased with non letter/number characters removed and spaces and underscores replaced with a separator (- by default)
  *
  * Example:
  * ```typescript
- * slugify("This is the blog post title!") //=> "this-is-the-blog-post-title"
+ * slugify("This is the 42nd blog post title!") //=> "this-is-the-42nd-blog-post-title"
  *
  * slugify("This is the blog post title!", "_") //=> "this_is_the_blog_post_title"
  * ```

--- a/gladney.ts
+++ b/gladney.ts
@@ -1937,6 +1937,17 @@ type CurryFunction<T> = T extends (...args: infer Args) => infer Result
     : never
   : never
 
+/** Returns a curried version of a function.
+ *
+ * Example:
+ * ```typescript
+ * const addThreeNumbers = (n1: number, n2: number, n3: number) => n1 + n2 + n3
+ *
+ * const curriedAdd3 = curry(addThreeNumbers)
+ *
+ * curriedAdd3(1)(2)(3) //=> 6
+ * ```
+ **/
 export function curry<T extends (...args: any[]) => any>(
   func: T
 ): CurryFunction<T> {

--- a/gladney.ts
+++ b/gladney.ts
@@ -1912,7 +1912,7 @@ sayHello("John") //=> "Hello John"
  **/
 export function partial<T extends (...args: any[]) => any>(
   func: T,
-  ...args: (Parameters<typeof func>[number] | Falsy)[]
+  ...args: (Parameters<T>[number] | Falsy)[]
 ) {
   const newArgsToCall: (Parameters<typeof func>[number] | Falsy)[] = []
   let lastNewArgUsed = -1
@@ -1927,6 +1927,25 @@ export function partial<T extends (...args: any[]) => any>(
     })
     return func(...newArgsToCall, ...newArgs.slice(lastNewArgUsed))
   }
+}
+
+type CurryFunction<T> = T extends (...args: infer Args) => infer Result
+  ? Args extends []
+    ? () => Result
+    : Args extends [infer First, ...infer Rest]
+    ? (arg: First) => CurryFunction<(...rest: Rest) => Result>
+    : never
+  : never
+
+export function curry<T extends (...args: any[]) => any>(
+  func: T
+): CurryFunction<T> {
+  function rf(func: Function, i: number, args: any[]): Function {
+    return args.length < func.length
+      ? (arg: any) => rf(func, i - 1, [...args, arg])
+      : func(...args)
+  }
+  return rf(func, func.length, []) as CurryFunction<T>
 }
 
 /** Prompts a user in their browser to save some specific text to a file on their machine.

--- a/gladney.ts
+++ b/gladney.ts
@@ -350,6 +350,40 @@ export function isPast(date: Date) {
   return new Date(date).getTime() < Date.now()
 }
 
+/** Returns the relative time difference of two dates
+ *
+ * Example:
+ *
+ * ```typescript
+ * const fiveMinutesAgo = new Date(Date.now() - 60 * 1000 * 5)
+ *
+ * getRelativeTimeDiff(fiveMinutesAgo) //=> "5 minutes ago"
+ * ```
+ */
+export function getRelativeTimeDiff(toDate: Date, fromDate: Date = new Date()) {
+  const TIME_UNITS: { n: number; unit: Intl.RelativeTimeFormatUnit }[] = [
+    { n: 60, unit: "seconds" },
+    { n: 60, unit: "minutes" },
+    { n: 24, unit: "hours" },
+    { n: 7, unit: "days" },
+    { n: 4, unit: "weeks" },
+    { n: 12, unit: "months" },
+    { n: Number.POSITIVE_INFINITY, unit: "years" },
+  ]
+
+  let duration = (toDate.getTime() - fromDate.getTime()) / 1000
+
+  for (let i = 0; i < TIME_UNITS.length; i++) {
+    const currentUnit = TIME_UNITS[i]
+    if (Math.abs(duration) < currentUnit.n) {
+      return new Intl.RelativeTimeFormat(undefined, {
+        numeric: "auto",
+      }).format(Math.round(duration), currentUnit.unit)
+    }
+    duration /= currentUnit.n
+  }
+}
+
 // STRINGS
 
 /** Returns a string in lowercase form with spaces removed.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gladknee",
-  "version": "1.5.8",
+  "version": "1.6.0",
   "description": "A utility library written in TypeScript",
   "main": "dist/gladney.js",
   "types": "dist/gladney.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -105,7 +105,7 @@
     // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
-    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+    // "allowUnreachableCode": true /* Disable error reporting for unreachable code. */,
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */


### PR DESCRIPTION
- Allow `clampNumber` to utilize zeros as limits
- `capitalize` handles multiple words
- Add `getRandomItems` to get more than one random item
- Add special characters to `getRandomString`
- Add `getRelativeTimeDiff` and `getTimeDiff` functions
- Remove weeks, months and years from time functions
- Remove conversion functions from `TimeObject`
- Add stronger type inference to `pipe`
- Add function overloads to functions that can receive multiple param types to determine return type
- Add `curry` function

Upon testing, there's a lot of wonkiness with months and years so removing that and recommending libraries like luxon to solve this problem.