### PR TITLE
Back in ATL (v1.7.0)

### DIFF
--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -963,6 +963,13 @@ describe("objects", () => {
       })
     })
   })
+
+  describe("getKeyWhereValueIs", () => {
+    it("returns the correct key", () => {
+      const obj = { a: 1, b: 2, c: 3 }
+      expect(_.getKeyWhereValueIs(obj, 3)).toBe("c")
+    })
+  })
 })
 
 describe("misc", () => {

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -56,15 +56,15 @@ describe("numbers", () => {
 })
 
 describe("time & dates", () => {
-  describe("getAmountOfTimeFromSeconds", () => {
-    it("returns the correct TimeOutput", () => {
-      const timeObject = _.getAmountOfTimeFromSeconds(200000)
-      expect(timeObject.days).toEqual(2)
-      expect(timeObject.hours).toEqual(7)
-      expect(timeObject.minutes).toEqual(33)
-      expect(timeObject.seconds).toEqual(20)
-    })
-  })
+  // describe("getAmountOfTimeFromSeconds", () => {
+  //   it("returns the correct TimeOutput", () => {
+  //     const timeObject = _.getAmountOfTimeFromSeconds(200000)
+  //     expect(timeObject.days).toEqual(2)
+  //     expect(timeObject.hours).toEqual(7)
+  //     expect(timeObject.minutes).toEqual(33)
+  //     expect(timeObject.seconds).toEqual(20)
+  //   })
+  // })
 
   describe("timeUntil", () => {
     it("returns the correct number of seconds until the provided time", () => {

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -634,13 +634,6 @@ describe("objects", () => {
     })
   })
 
-  describe("combineObjects", () => {
-    it("returns an object with all key/values from provided objects", () => {
-      const objArray = [{ a: 1 }, { b: 2 }, { c: 3 }]
-      expect(_.combineObjects(...objArray)).toEqual({ a: 1, b: 2, c: 3 })
-    })
-  })
-
   describe("sumOfKeyValue", () => {
     it("returns the sum of the key value", () => {
       const arr = [

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -201,7 +201,7 @@ describe("time & dates", () => {
       end.setMinutes(end.getMinutes() - 5)
       end.setSeconds(end.getSeconds() - 43)
 
-      expect(_.getDurationFromDates(start, end)).toEqual({
+      expect(_.getDuration(start, end)).toEqual({
         days: 11,
         hours: 2,
         minutes: 5,

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -32,15 +32,15 @@ describe("numbers", () => {
     })
   })
 
-  describe("getRange", () => {
+  describe("createRange", () => {
     it("returns a range of numbers", () => {
-      expect(_.getRange(1, 5)).toEqual([1, 2, 3, 4, 5])
+      expect(_.createRange(1, 5)).toEqual([1, 2, 3, 4, 5])
     })
     it("uses the step parameter", () => {
-      expect(_.getRange(2, 10, 2)).toEqual([2, 4, 6, 8, 10])
+      expect(_.createRange(2, 10, 2)).toEqual([2, 4, 6, 8, 10])
     })
     it("can create a decreasing sequence", () => {
-      expect(_.getRange(-2, -10, -2)).toEqual([-2, -4, -6, -8, -10])
+      expect(_.createRange(-2, -10, -2)).toEqual([-2, -4, -6, -8, -10])
     })
   })
   describe("ordinal", () => {
@@ -156,15 +156,15 @@ describe("time & dates", () => {
     })
   })
 
-  describe("getDayName", () => {
+  describe("dayName", () => {
     it("returns the correct day name", () => {
-      expect(_.getDayName(0)).toBe("Sunday")
-      expect(_.getDayName(1)).toBe("Monday")
-      expect(_.getDayName(2)).toBe("Tuesday")
-      expect(_.getDayName(3)).toBe("Wednesday")
-      expect(_.getDayName(4)).toBe("Thursday")
-      expect(_.getDayName(5)).toBe("Friday")
-      expect(_.getDayName(6)).toBe("Saturday")
+      expect(_.dayName(0)).toBe("Sunday")
+      expect(_.dayName(1)).toBe("Monday")
+      expect(_.dayName(2)).toBe("Tuesday")
+      expect(_.dayName(3)).toBe("Wednesday")
+      expect(_.dayName(4)).toBe("Thursday")
+      expect(_.dayName(5)).toBe("Friday")
+      expect(_.dayName(6)).toBe("Saturday")
     })
   })
 
@@ -511,10 +511,10 @@ describe("arrays", () => {
     })
   })
 
-  describe("getRollingSum", () => {
+  describe("rollingSum", () => {
     it("returns the rolling sum of an array of numbers", () => {
       const arr = [1, 2, 3, 4]
-      expect(_.getRollingSum(arr)).toEqual([1, 3, 6, 10])
+      expect(_.rollingSum(arr)).toEqual([1, 3, 6, 10])
     })
   })
 

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -969,6 +969,11 @@ describe("objects", () => {
       const obj = { a: 1, b: 2, c: 3 }
       expect(_.getKeyWhereValueIs(obj, 3)).toBe("c")
     })
+
+    it("returns null if no key/value found", () => {
+      const obj = { a: 1, b: 2, c: 3 }
+      expect(_.getKeyWhereValueIs(obj, 4)).toBe(null)
+    })
   })
 })
 

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -32,15 +32,15 @@ describe("numbers", () => {
     })
   })
 
-  describe("createRange", () => {
+  describe("range", () => {
     it("returns a range of numbers", () => {
-      expect(_.createRange(1, 5)).toEqual([1, 2, 3, 4, 5])
+      expect(_.range(1, 5)).toEqual([1, 2, 3, 4, 5])
     })
     it("uses the step parameter", () => {
-      expect(_.createRange(2, 10, 2)).toEqual([2, 4, 6, 8, 10])
+      expect(_.range(2, 10, 2)).toEqual([2, 4, 6, 8, 10])
     })
     it("can create a decreasing sequence", () => {
-      expect(_.createRange(-2, -10, -2)).toEqual([-2, -4, -6, -8, -10])
+      expect(_.range(-2, -10, -2)).toEqual([-2, -4, -6, -8, -10])
     })
   })
   describe("ordinal", () => {
@@ -201,7 +201,7 @@ describe("time & dates", () => {
       end.setMinutes(end.getMinutes() - 5)
       end.setSeconds(end.getSeconds() - 43)
 
-      expect(_.getDurationBetweenDates(start, end)).toEqual({
+      expect(_.getDurationFromDates(start, end)).toEqual({
         days: 11,
         hours: 2,
         minutes: 5,

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -210,7 +210,7 @@ describe("time & dates", () => {
     })
   })
 
-  describe("getRelativeTimeDiff", () => {
+  describe("relativeTimeDiff", () => {
     it("returns the correct relative duration", () => {
       const secondsInAMinute = 60
       const secondsInAnHour = 3600
@@ -226,12 +226,12 @@ describe("time & dates", () => {
       const fiveMinutesAgo = new Date(Date.now() - secondsInAMinute * 1000 * 5)
       const sixHoursAgo = new Date(Date.now() - secondsInAnHour * 1000 * 6)
 
-      expect(_.getRelativeTimeDiff(oneDayAgo)).toBe("yesterday")
-      expect(_.getRelativeTimeDiff(twoWeeksAgo)).toBe("2 weeks ago")
-      expect(_.getRelativeTimeDiff(threeMonthsAgo)).toBe("3 months ago")
-      expect(_.getRelativeTimeDiff(fourYearsAgo)).toBe("4 years ago")
-      expect(_.getRelativeTimeDiff(fiveMinutesAgo)).toBe("5 minutes ago")
-      expect(_.getRelativeTimeDiff(sixHoursAgo)).toBe("6 hours ago")
+      expect(_.relativeTimeDiff(oneDayAgo)).toBe("yesterday")
+      expect(_.relativeTimeDiff(twoWeeksAgo)).toBe("2 weeks ago")
+      expect(_.relativeTimeDiff(threeMonthsAgo)).toBe("3 months ago")
+      expect(_.relativeTimeDiff(fourYearsAgo)).toBe("4 years ago")
+      expect(_.relativeTimeDiff(fiveMinutesAgo)).toBe("5 minutes ago")
+      expect(_.relativeTimeDiff(sixHoursAgo)).toBe("6 hours ago")
     })
   })
 

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -56,15 +56,73 @@ describe("numbers", () => {
 })
 
 describe("time & dates", () => {
-  // describe("getAmountOfTimeFromSeconds", () => {
+  // describe("getDurationFromMilliseconds", () => {
   //   it("returns the correct TimeOutput", () => {
-  //     const timeObject = _.getAmountOfTimeFromSeconds(200000)
+  //     const timeObject = _.getDurationFromMilliseconds(200000000)
   //     expect(timeObject.days).toEqual(2)
   //     expect(timeObject.hours).toEqual(7)
   //     expect(timeObject.minutes).toEqual(33)
   //     expect(timeObject.seconds).toEqual(20)
   //   })
   // })
+
+  // describe("getMillisecondsFromDuration", () => {
+  //   it("returns the correct number of ms", () => {
+  //     const amountOfTime = { days: 1, hours: 3, minutes: 24, seconds: 11 }
+  //     expect(_.getMillisecondsFromDuration(amountOfTime)).toBe(98651000)
+  //   })
+  // })
+
+  // describe("duration functions", () => {
+  //   it("handles the same amount of time correctly", () => {
+  //     const amountOfTime = { days: 1, hours: 3, minutes: 24, seconds: 11 }
+  //     const toMs = _.getMillisecondsFromDuration(amountOfTime)
+  //     const backToTime = _.getDurationFromMilliseconds(toMs)
+  //     expect(backToTime).toEqual(amountOfTime)
+  //   })
+  // })
+
+  describe("getDateFromDuration", () => {
+    const now = new Date()
+
+    it("returns the correct date in the past", () => {
+      const then = new Date(now)
+
+      then.setDate(then.getDate() - 1)
+      then.setHours(then.getHours() - 2)
+      then.setMinutes(then.getMinutes() - 3)
+      then.setSeconds(then.getSeconds() - 4)
+
+      const fnResult = _.getDateFromDuration(
+        { days: 1, hours: 2, minutes: 3, seconds: 4 },
+        "past"
+      )
+
+      expect(fnResult.getDate()).toBe(then.getDate())
+      expect(fnResult.getHours()).toBe(then.getHours())
+      expect(fnResult.getMinutes()).toBe(then.getMinutes())
+      expect(fnResult.getSeconds()).toBe(then.getSeconds())
+    })
+
+    it("returns the correct date in the future", () => {
+      const then = new Date(now)
+
+      then.setDate(then.getDate() + 1)
+      then.setHours(then.getHours() + 2)
+      then.setMinutes(then.getMinutes() + 3)
+      then.setSeconds(then.getSeconds() + 4)
+
+      const fnResult = _.getDateFromDuration(
+        { days: 1, hours: 2, minutes: 3, seconds: 4 },
+        "future"
+      )
+
+      expect(fnResult.getDate()).toBe(then.getDate())
+      expect(fnResult.getHours()).toBe(then.getHours())
+      expect(fnResult.getMinutes()).toBe(then.getMinutes())
+      expect(fnResult.getSeconds()).toBe(then.getSeconds())
+    })
+  })
 
   describe("timeUntil", () => {
     it("returns the correct number of seconds until the provided time", () => {
@@ -134,7 +192,7 @@ describe("time & dates", () => {
     })
   })
 
-  describe("getTimeDiff", () => {
+  describe("getDurationBetweenDates", () => {
     it("returns the correct duration", () => {
       const start = new Date()
       const end = new Date(start)
@@ -143,7 +201,7 @@ describe("time & dates", () => {
       end.setMinutes(end.getMinutes() - 5)
       end.setSeconds(end.getSeconds() - 43)
 
-      expect(_.getTimeDiff(start, end)).toEqual({
+      expect(_.getDurationBetweenDates(start, end)).toEqual({
         days: 11,
         hours: 2,
         minutes: 5,

--- a/gladney.ts
+++ b/gladney.ts
@@ -80,17 +80,17 @@ export function doubleDigit(n: number) {
  *
  * _Example:_
  * ```typescript
- * getRange(5, 10)
+ * createRange(5, 10)
  * //=> [5, 6, 7, 8, 9, 10]
  *
- * getRange(0, 10, 2)
+ * createRange(0, 10, 2)
  * //=> [0, 2, 4, 6, 8, 10]
  *
- * getRange(10, 0, -2)
+ * createRange(10, 0, -2)
  * //=> [10, 8, 6, 4, 2, 0]
  * ```
  **/
-export function getRange(start: number, end: number, step = 1) {
+export function createRange(start: number, end: number, step = 1) {
   const result: number[] = []
   if (start < end) {
     if (step <= 0) return
@@ -219,7 +219,7 @@ interface TimeObject {
 }
  * ```
  **/
-export function getDurationFromMilliseconds(milliseconds: number): TimeObject {
+function getDurationFromMilliseconds(milliseconds: number): TimeObject {
   const seconds = Math.floor(milliseconds / 1000)
 
   return {
@@ -240,7 +240,7 @@ export function getDurationFromMilliseconds(milliseconds: number): TimeObject {
  * getMillisecondsFromDuration(amountOfTime) //=> 98651000
  * ```
  */
-export function getMillisecondsFromDuration(duration: Partial<TimeObject>) {
+function getMillisecondsFromDuration(duration: Partial<TimeObject>) {
   let result = 0
   if (duration.days) result += duration.days * secondsInADay * 1000
   if (duration.hours) result += duration.hours * secondsInAnHour * 1000
@@ -319,10 +319,10 @@ type DayName =
  *
  * Example:
  * ```typescript
- * getDayName(3) //=> "Wednesday"
+ * dayName(3) //=> "Wednesday"
  * ```
  **/
-export function getDayName(day: 0 | 1 | 2 | 3 | 4 | 5 | 6) {
+export function dayName(day: 0 | 1 | 2 | 3 | 4 | 5 | 6) {
   const dayNames: DayName[] = [
     "Sunday",
     "Monday",
@@ -364,7 +364,7 @@ export function isPast(date: Date) {
  * ```typescript
  * const fiveMinutesAgo = new Date(Date.now() - 60 * 1000 * 5)
  *
- * getTimeDiff(new Date(), fiveMinutesAgo) //=>
+ * getDurationBetweenDates(new Date(), fiveMinutesAgo) //=>
  *  {
  *    days: 0,
  *    hours: 0,
@@ -978,7 +978,7 @@ export function removeDuplicates<T>(arr: T[]): T[] {
 
 /** Returns an array of the rolling sum of an array of numbers.
  **/
-export function getRollingSum(arr: number[], precision?: number) {
+export function rollingSum(arr: number[], precision?: number) {
   return arr.reduce(
     (acc: number[], i, index) =>
       index > 0

--- a/gladney.ts
+++ b/gladney.ts
@@ -1323,8 +1323,8 @@ export function getKeyValueCounts<T extends object, U extends keyof T>(
 ) {
   return arr.reduce((result: { [key: string]: number }, obj) => {
     const value = isCaseSensitive
-      ? (obj[key] as string)
-      : (obj[key] as string).toLowerCase()
+      ? String(obj[key])
+      : String(obj[key]).toLowerCase()
     if (result[value] > 0) {
       result[value] = result[value] + 1
       return result

--- a/gladney.ts
+++ b/gladney.ts
@@ -190,7 +190,6 @@ export interface TimeObject {
   seconds: number
 }
 
-const millisecondsInASecond = 1000
 const secondsInAMinute = 60
 const secondsInAnHour = 3600
 const secondsInADay = 86400
@@ -220,7 +219,9 @@ interface TimeObject {
 }
  * ```
  **/
-export function getAmountOfTimeFromSeconds(seconds: number): TimeObject {
+function getDurationFromMilliseconds(milliseconds: number): TimeObject {
+  const seconds = Math.floor(milliseconds / 1000)
+
   return {
     days: Math.floor(seconds / secondsInADay),
     hours: Math.floor((seconds % secondsInADay) / secondsInAnHour),
@@ -241,10 +242,8 @@ interface TimeObject {
  * ```
  **/
 export function timeUntil(date: Date): TimeObject {
-  const diffInSeconds = Math.floor(
-    (new Date(date).getTime() - Date.now()) / 1000
-  )
-  return getAmountOfTimeFromSeconds(diffInSeconds)
+  const diff = new Date(date).getTime() - Date.now()
+  return getDurationFromMilliseconds(diff)
 }
 
 /** Returns a `TimeObject` with the number of years, months, weeks, days, hours, minutes and seconds since a
@@ -259,10 +258,8 @@ interface TimeObject {
  * ```
  **/
 export function timeSince(date: Date): TimeObject {
-  const diffInSeconds = Math.floor(
-    (Date.now() - new Date(date).getTime()) / 1000
-  )
-  return getAmountOfTimeFromSeconds(diffInSeconds)
+  const diff = Date.now() - new Date(date).getTime()
+  return getDurationFromMilliseconds(diff)
 }
 
 type DayName =
@@ -333,8 +330,8 @@ export function isPast(date: Date) {
  * ```
  */
 export function getTimeDiff(dateA: Date, dateB: Date) {
-  const diff = Math.abs((dateA.getTime() - dateB.getTime()) / 1000)
-  return getAmountOfTimeFromSeconds(diff)
+  const diff = Math.abs(dateA.getTime() - dateB.getTime())
+  return getDurationFromMilliseconds(diff)
 }
 
 /** Returns the relative time difference of two dates

--- a/gladney.ts
+++ b/gladney.ts
@@ -1199,37 +1199,6 @@ export function pickKeys<T extends object, U extends keyof T>(
   return result as Pick<T, U>
 }
 
-/** Returns a single object with all of the key value pairs from two or more objects.
- *
- * Example:
- * ```typescript
- * const obj1 = { a: 1, b: 2, c: 3 }
- * const obj2 = { d: 4, e: 5, f: 6 }
- *
- * combineObjects(obj1, obj2)
- * //=>
- *     {
- *      a: 1,
- *      b: 2,
- *      c: 3,
- *      d: 4,
- *      e: 5,
- *      f: 6
- *     }
- * ```
- *
- * NOTE: If two objects have the same key, the latter object's value will result.
- **/
-export function combineObjects(...objs: object[]): object {
-  const result: { [key: string]: any } = {}
-  objs.forEach((obj) => {
-    Object.keys(obj).forEach((key) => {
-      result[key] = obj[key as keyof object]
-    })
-  })
-  return result
-}
-
 /** Returns the sum of the values of a specific shared key in an array of objects.
  *
  * Example:

--- a/gladney.ts
+++ b/gladney.ts
@@ -80,17 +80,17 @@ export function doubleDigit(n: number) {
  *
  * _Example:_
  * ```typescript
- * createRange(5, 10)
+ * range(5, 10)
  * //=> [5, 6, 7, 8, 9, 10]
  *
- * createRange(0, 10, 2)
+ * range(0, 10, 2)
  * //=> [0, 2, 4, 6, 8, 10]
  *
- * createRange(10, 0, -2)
+ * range(10, 0, -2)
  * //=> [10, 8, 6, 4, 2, 0]
  * ```
  **/
-export function createRange(start: number, end: number, step = 1) {
+export function range(start: number, end: number, step = 1) {
   const result: number[] = []
   if (start < end) {
     if (step <= 0) return
@@ -288,7 +288,7 @@ interface TimeObject {
  **/
 
 export function timeUntil(date: Date): TimeObject {
-  return getDurationBetweenDates(new Date(), new Date(date))
+  return getDurationFromDates(new Date(), new Date(date))
 }
 
 /** Returns a `TimeObject` with the number of years, months, weeks, days, hours, minutes and seconds since a
@@ -303,7 +303,7 @@ interface TimeObject {
  * ```
  **/
 export function timeSince(date: Date): TimeObject {
-  return getDurationBetweenDates(new Date(), new Date(date))
+  return getDurationFromDates(new Date(), new Date(date))
 }
 
 type DayName =
@@ -364,7 +364,7 @@ export function isPast(date: Date) {
  * ```typescript
  * const fiveMinutesAgo = new Date(Date.now() - 60 * 1000 * 5)
  *
- * getDurationBetweenDates(new Date(), fiveMinutesAgo) //=>
+ * getDurationFromDates(new Date(), fiveMinutesAgo) //=>
  *  {
  *    days: 0,
  *    hours: 0,
@@ -373,7 +373,7 @@ export function isPast(date: Date) {
  *  }
  * ```
  */
-export function getDurationBetweenDates(dateA: Date, dateB: Date) {
+export function getDurationFromDates(dateA: Date, dateB: Date) {
   const diff = Math.abs(dateA.getTime() - dateB.getTime())
   return getDurationFromMilliseconds(diff)
 }

--- a/gladney.ts
+++ b/gladney.ts
@@ -1587,6 +1587,26 @@ export function getKeyWithLargestValue<T extends object>(obj: T) {
   } else return result[0].key
 }
 
+/** Returns the first key in an object with a particular value (or null if none is found)
+ *
+ *
+ * Example:
+ * ```typescript
+ * const obj = {a: 1, b: 2, c: 3}
+ *
+ * getKeyWhereValueIs(obj, 3) //=> "c"
+ * ```
+ */
+export function getKeyWhereValueIs<T extends object>(
+  obj: T,
+  value: any
+): string | null {
+  for (let key in obj) {
+    if (obj[key] === value) return key
+  }
+  return null
+}
+
 /**
  * Runs a callback function on array of items and returns a single object with keys that match the return values.
  * Each key's value is an array of items that provide the same result when having the callback function run on them.

--- a/gladney.ts
+++ b/gladney.ts
@@ -2048,8 +2048,8 @@ export async function getBrowserGeolocation(timeoutInSeconds = 10) {
       browserLocation.latitude = coords.latitude
       browserLocation.longitude = coords.longitude
     },
-    () => {
-      err = "Unable to get location"
+    (error) => {
+      err = String(error)
     }
   )
   while (browserLocation.latitude === null && err === null) {
@@ -2075,6 +2075,15 @@ export function getURLQueryParams() {
       }
     } else return { ...acc, [key]: value }
   }, {})
+}
+
+/** Returns the browser's display mode (light of dark)
+ **/
+export function getBrowserDisplayMode(): "light" | "dark" {
+  return window.matchMedia &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light"
 }
 
 /** A function that does nothing and returns nothing. Useful for linters that require a callback. */

--- a/gladney.ts
+++ b/gladney.ts
@@ -1076,8 +1076,8 @@ export function swapItems<T>(arr: T[], index1: number, index2: number) {
  * NOTE: `orderMatters` is false by default.
  **/
 export function isEqual(
-  thing1: object | [],
-  thing2: object | [],
+  thing1: object | any[],
+  thing2: object | any[],
   orderMatters = false,
   isCaseSensitive = false
 ) {

--- a/gladney.ts
+++ b/gladney.ts
@@ -1402,9 +1402,9 @@ export function removeDuplicatesByKeyValue<T extends object, U extends keyof T>(
   isCaseSensitive = false
 ) {
   const groupedByKey = groupByKeyValue(arr, key, isCaseSensitive)
-  return Object.keys(groupedByKey).reduce((acc, _key) => {
-    return [...acc, groupedByKey[_key][0]]
-  }, [] as T[])
+  return Object.keys(groupedByKey).reduce((acc: T[], k) => {
+    return [...acc, groupedByKey[k][0]]
+  }, [])
 }
 
 /** Returns a string of an object's key and value pairs as a query parameter string. Supports one level of nesting.
@@ -1625,8 +1625,8 @@ sortByCallbackResult(socialStats, getPopularity)
 export function sortByCallbackResult<T>(things: T[], func: Function) {
   const groupedByResult = groupByCallbackResult(things, func)
   return safeSort(Object.keys(groupedByResult)).reduce(
-    (acc, key) => [...acc, ...groupedByResult[key]],
-    [] as T[]
+    (acc: T[], key) => [...acc, ...groupedByResult[key]],
+    []
   )
 }
 

--- a/gladney.ts
+++ b/gladney.ts
@@ -261,6 +261,15 @@ export function timeSince(date: Date): TimeObject {
   return getAmountOfTimeFromSeconds(diffInSeconds)
 }
 
+type DayName =
+  | "Sunday"
+  | "Monday"
+  | "Tuesday"
+  | "Wednesday"
+  | "Thursday"
+  | "Friday"
+  | "Saturday"
+
 /** Returns the corresponding human readable day name of an integer (0-6).
  *
  * Example:
@@ -269,7 +278,7 @@ export function timeSince(date: Date): TimeObject {
  * ```
  **/
 export function getDayName(day: 0 | 1 | 2 | 3 | 4 | 5 | 6) {
-  const dayNames = [
+  const dayNames: DayName[] = [
     "Sunday",
     "Monday",
     "Tuesday",

--- a/gladney.ts
+++ b/gladney.ts
@@ -938,11 +938,11 @@ export function removeDuplicates<T>(arr: T[]): T[] {
  **/
 export function getRollingSum(arr: number[], precision?: number) {
   return arr.reduce(
-    (acc, i, index) =>
+    (acc: number[], i, index) =>
       index > 0
         ? [...acc, round(acc[acc.length - 1] + Number(i), precision ?? 1)]
         : [i],
-    [] as number[]
+    []
   )
 }
 
@@ -952,8 +952,9 @@ export function getRollingSum(arr: number[], precision?: number) {
 export function getCounts<T>(arr: T[]): { [key: string]: number } {
   const result: { [key: string]: number } = {}
   arr.forEach((item) => {
-    if (result[item as string]) result[item as string]++
-    else result[item as string] = 1
+    const itemAsString = String(item)
+    if (result[itemAsString]) result[itemAsString]++
+    else result[itemAsString] = 1
   })
   return result
 }
@@ -967,7 +968,7 @@ export function getCounts<T>(arr: T[]): { [key: string]: number } {
  * ```
  **/
 export function getCountOf<T>(arr: T[], target: T) {
-  return getCounts(arr)[target as string] || 0
+  return getCounts(arr)[String(target)] || 0
 }
 
 /** Returns an array of items that only appear in one of the given arrays.
@@ -1103,8 +1104,8 @@ export function isEqual(
       )
     }
   } else if (Array.isArray(thing1) && Array.isArray(thing2)) {
-    const _thing1 = [...(thing1 as [])].sort()
-    const _thing2 = [...(thing2 as [])].sort()
+    const _thing1 = [...thing1].sort()
+    const _thing2 = [...thing2].sort()
     for (let i = 0; i < thing1.length; i++) {
       const thing1value = isCaseSensitive
         ? _thing1[i]
@@ -1166,13 +1167,13 @@ export function omitKeys<T extends object, U extends keyof T>(
   ...keys: U[]
 ) {
   const result: { [key: string]: any } = {}
-  const keysAsStrings = keys.map((k) => k as string)
-  Object.keys(obj).forEach((key: string) => {
+  const keysAsStrings = keys.map((k) => String(k))
+  Object.keys(obj).forEach((key) => {
     if (!keysAsStrings.includes(key)) {
-      result[key as string] = obj[key as U]
+      result[key] = obj[key as U]
     }
   })
-  return result as Partial<T>
+  return result as Omit<T, U>
 }
 
 /** Returns an object with only the specific keys included.
@@ -1195,7 +1196,7 @@ export function pickKeys<T extends object, U extends keyof T>(
       result[key] = obj[key as U]
     }
   })
-  return result as Partial<T>
+  return result as Pick<T, U>
 }
 
 /** Returns a single object with all of the key value pairs from two or more objects.

--- a/gladney.ts
+++ b/gladney.ts
@@ -190,6 +190,7 @@ export interface TimeObject {
   seconds: number
 }
 
+const millisecondsInASecond = 1000
 const secondsInAMinute = 60
 const secondsInAnHour = 3600
 const secondsInADay = 86400
@@ -226,6 +227,20 @@ export function getAmountOfTimeFromSeconds(seconds: number): TimeObject {
     minutes: Math.floor((seconds % secondsInAnHour) / secondsInAMinute),
     seconds: seconds % secondsInAMinute,
   }
+}
+
+/** Returns a `TimeObject` with calculated days, hours, minutes and seconds from an amount of seconds.
+ *
+ * _Example:_
+ * ```typescript
+ * getAmountOfTimeFromMilliseconds(65000) //=> { days: 0, hours: 0, minutes: 1, seconds: 5 }
+ *
+ * ```
+ **/
+export function getAmountOfTimeFromMilliseconds(
+  milliseconds: number
+): TimeObject {
+  return getAmountOfTimeFromSeconds(Math.floor(milliseconds / 1000))
 }
 
 /** Returns a `TimeObject` with the number of years, months, weeks, days, hours, minutes and seconds until 

--- a/gladney.ts
+++ b/gladney.ts
@@ -166,18 +166,21 @@ export function median(...numbers: (number | number[])[]) {
  *
  * _Example:_
  * ```typescript
-x * mode(1, 2, 3, 4, 5) //=> 2
+x * mode(1, 2, 3, 4, 5) //=> null
  *
- * mode([1, 2, 3, 4, 5]) //=> 2
+ * mode([1, 2, 2, 3, 4, 5]) //=> 2
  *
  * mode(1, 2, 2, 3, 4, 4, 5) //=> [2, 4]
  * ```
  **/
 export function mode(...numbers: (number | number[])[]) {
-  const counts = getCounts(flatten(numbers))
+  const flattened = flatten(numbers)
+  const counts = getCounts(flattened)
   const mostCommon = getKeyWithLargestValue(counts)
-  if (Array.isArray(mostCommon)) return mostCommon.map((key) => Number(key))
-  else return Number(mostCommon)
+  if (Array.isArray(mostCommon)) {
+    if (mostCommon.length === flattened.length) return null
+    else return mostCommon.map((key) => Number(key))
+  } else return Number(mostCommon)
 }
 
 export interface TimeObject {

--- a/gladney.ts
+++ b/gladney.ts
@@ -229,20 +229,6 @@ export function getAmountOfTimeFromSeconds(seconds: number): TimeObject {
   }
 }
 
-/** Returns a `TimeObject` with calculated days, hours, minutes and seconds from an amount of seconds.
- *
- * _Example:_
- * ```typescript
- * getAmountOfTimeFromMilliseconds(65000) //=> { days: 0, hours: 0, minutes: 1, seconds: 5 }
- *
- * ```
- **/
-export function getAmountOfTimeFromMilliseconds(
-  milliseconds: number
-): TimeObject {
-  return getAmountOfTimeFromSeconds(Math.floor(milliseconds / 1000))
-}
-
 /** Returns a `TimeObject` with the number of years, months, weeks, days, hours, minutes and seconds until 
  * a specific date. A `TimeObject` also includes methods to measure the amount of time in a specific unit (i.e. minutes)
  * ```typescript

--- a/gladney.ts
+++ b/gladney.ts
@@ -198,8 +198,8 @@ const secondsInADay = 86400
  *
  * _Example:_
  * ```typescript
- * getAmountOfTimeFromSeconds(2000000)
-//=> { days: 23, hours: 3, minutes: 33, seconds: 20 }
+ * getDurationFromMilliseconds(200000000)
+//=> { days: 2, hours: 7, minutes: 33, seconds: 20 }
 
 interface TimeObject {
   years: number
@@ -219,7 +219,7 @@ interface TimeObject {
 }
  * ```
  **/
-function getDurationFromMilliseconds(milliseconds: number): TimeObject {
+export function getDurationFromMilliseconds(milliseconds: number): TimeObject {
   const seconds = Math.floor(milliseconds / 1000)
 
   return {
@@ -228,6 +228,51 @@ function getDurationFromMilliseconds(milliseconds: number): TimeObject {
     minutes: Math.floor((seconds % secondsInAnHour) / secondsInAMinute),
     seconds: seconds % secondsInAMinute,
   }
+}
+
+/** Returns the number of milliseconds from an amount of time
+ *
+ * Example:
+ *
+ * ```typescript
+ * const amountOfTime = {days: 1, hours: 3, minutes: 24, seconds: 11}
+ *
+ * getMillisecondsFromDuration(amountOfTime) //=> 98651000
+ * ```
+ */
+export function getMillisecondsFromDuration(duration: Partial<TimeObject>) {
+  let result = 0
+  if (duration.days) result += duration.days * secondsInADay * 1000
+  if (duration.hours) result += duration.hours * secondsInAnHour * 1000
+  if (duration.minutes) result += duration.minutes * secondsInAMinute * 1000
+  if (duration.seconds) result += duration.seconds * 1000
+  return result
+}
+
+/** Returns a date in the future or past based on a duration from now
+ *
+ * Example:
+ *
+ * ```typescript
+ * const fromDate = new Date("Jan 1, 2024 12:00:00AM")
+ * //=> Date: "2024-01-01T05:00:00.000Z"
+ *
+ * getDateFromDuration({days: 1: hours: 2, minutes: 3, seconds: 4}, "future", fromDate)
+ * //=> Date: "2024-01-02T07:03:04.000Z"
+ *
+ * getDateFromDuration({days: 1: hours: 2, minutes: 3, seconds: 4}, "past", fromDate)
+ * //=> Date: "2023-12-31T02:56:56.000Z"
+ * ```
+ */
+export function getDateFromDuration(
+  duration: Partial<TimeObject>,
+  inThe: "past" | "future",
+  startDate: Date = new Date()
+) {
+  const ms = getMillisecondsFromDuration(duration)
+  return inThe === "future"
+    ? new Date(startDate.getTime() + ms)
+    : new Date(startDate.getTime() - ms)
 }
 
 /** Returns a `TimeObject` with the number of years, months, weeks, days, hours, minutes and seconds until 
@@ -241,8 +286,9 @@ interface TimeObject {
 }
  * ```
  **/
+
 export function timeUntil(date: Date): TimeObject {
-  return getTimeDiff(new Date(), new Date(date))
+  return getDurationBetweenDates(new Date(), new Date(date))
 }
 
 /** Returns a `TimeObject` with the number of years, months, weeks, days, hours, minutes and seconds since a
@@ -257,7 +303,7 @@ interface TimeObject {
  * ```
  **/
 export function timeSince(date: Date): TimeObject {
-  return getTimeDiff(new Date(), new Date(date))
+  return getDurationBetweenDates(new Date(), new Date(date))
 }
 
 type DayName =
@@ -327,7 +373,7 @@ export function isPast(date: Date) {
  *  }
  * ```
  */
-export function getTimeDiff(dateA: Date, dateB: Date) {
+export function getDurationBetweenDates(dateA: Date, dateB: Date) {
   const diff = Math.abs(dateA.getTime() - dateB.getTime())
   return getDurationFromMilliseconds(diff)
 }
@@ -562,16 +608,16 @@ export function unEscapeString(str: string) {
  * 
  * Example:
  * ```typescript
- getRandomString(10) //=> "N3xO1pDs2f"
+ randomString(10) //=> "N3xO1pDs2f"
 
-getRandomString(5, true, false) //=> "GjOxa"
+randomString(5, true, false) //=> "GjOxa"
 
-getRandomString(5, false, true) //=> "39281"
+randomString(5, false, true) //=> "39281"
 
-getRandomString(5, true, true, true) //=> "G2a$k!"
+randomString(5, true, true, true) //=> "G2a$k!"
  * ```
  **/
-export function getRandomString(
+export function randomString(
   length: number,
   includeLetters = true,
   includeNumbers = true,

--- a/gladney.ts
+++ b/gladney.ts
@@ -385,10 +385,10 @@ export function getDuration(dateA: Date, dateB: Date) {
  * ```typescript
  * const fiveMinutesAgo = new Date(Date.now() - 60 * 1000 * 5)
  *
- * getRelativeTime(fiveMinutesAgo) //=> "5 minutes ago"
+ * relativeTimeDiff(fiveMinutesAgo) //=> "5 minutes ago"
  * ```
  */
-export function getRelativeTimeDiff(to: Date, from: Date = new Date()) {
+export function relativeTimeDiff(to: Date, from: Date = new Date()) {
   const TIME_UNITS: { n: number; unit: Intl.RelativeTimeFormatUnit }[] = [
     { n: 60, unit: "seconds" },
     { n: 60, unit: "minutes" },

--- a/gladney.ts
+++ b/gladney.ts
@@ -242,8 +242,7 @@ interface TimeObject {
  * ```
  **/
 export function timeUntil(date: Date): TimeObject {
-  const diff = new Date(date).getTime() - Date.now()
-  return getDurationFromMilliseconds(diff)
+  return getTimeDiff(new Date(), new Date(date))
 }
 
 /** Returns a `TimeObject` with the number of years, months, weeks, days, hours, minutes and seconds since a
@@ -258,8 +257,7 @@ interface TimeObject {
  * ```
  **/
 export function timeSince(date: Date): TimeObject {
-  const diff = Date.now() - new Date(date).getTime()
-  return getDurationFromMilliseconds(diff)
+  return getTimeDiff(new Date(), new Date(date))
 }
 
 type DayName =

--- a/gladney.ts
+++ b/gladney.ts
@@ -1009,7 +1009,7 @@ export function getCounts<T>(arr: T[]): { [key: string]: number } {
  getCount(arr, 4) //=> 3
  * ```
  **/
-export function getCountOf<T>(arr: T[], target: T) {
+export function getCount<T>(arr: T[], target: T) {
   return getCounts(arr)[String(target)] || 0
 }
 

--- a/gladney.ts
+++ b/gladney.ts
@@ -288,7 +288,7 @@ interface TimeObject {
  **/
 
 export function timeUntil(date: Date): TimeObject {
-  return getDurationFromDates(new Date(), new Date(date))
+  return getDuration(new Date(), new Date(date))
 }
 
 /** Returns a `TimeObject` with the number of years, months, weeks, days, hours, minutes and seconds since a
@@ -303,7 +303,7 @@ interface TimeObject {
  * ```
  **/
 export function timeSince(date: Date): TimeObject {
-  return getDurationFromDates(new Date(), new Date(date))
+  return getDuration(new Date(), new Date(date))
 }
 
 type DayName =
@@ -364,7 +364,7 @@ export function isPast(date: Date) {
  * ```typescript
  * const fiveMinutesAgo = new Date(Date.now() - 60 * 1000 * 5)
  *
- * getDurationFromDates(new Date(), fiveMinutesAgo) //=>
+ * getDuration(new Date(), fiveMinutesAgo) //=>
  *  {
  *    days: 0,
  *    hours: 0,
@@ -373,7 +373,7 @@ export function isPast(date: Date) {
  *  }
  * ```
  */
-export function getDurationFromDates(dateA: Date, dateB: Date) {
+export function getDuration(dateA: Date, dateB: Date) {
   const diff = Math.abs(dateA.getTime() - dateB.getTime())
   return getDurationFromMilliseconds(diff)
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gladknee",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "A utility library written in TypeScript",
   "main": "dist/gladney.js",
   "types": "dist/gladney.d.ts",


### PR DESCRIPTION
- FIx `mode` to return `null` if the set of numbers contains no mode
- Enforce stronger typing for result of `getDayName`
- Remove `combineObjects` bc not type safe and not necessary
- Add `getBrowserDisplayMode`
- Add `getKeyWhereValueIs`
- Change `getAmountofTimeFromSeconds` to `getDurationFromMilliseconds`
- Obscure above function from end user
- Add `getDateFromDuration`
- Change user-facing function names...

`getDayName` -> `dayName`
`getRandomString` -> `randomString`
`getRange` -> `range`
`getRollingSum` -> `rollingSum`
`getTimeDiff` -> `getDuration`
`getRelativeTimDiff` -> `relativeTimeDiff`