### PR TITLE
1-27-24 (v1.8.0)

### DIFF
--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -1112,26 +1112,24 @@ describe("misc", () => {
     it("immediate = true. does not invoke the function again before time has passed", () => {
       const func = jest.fn()
       const debouncedFunc = _.debounce(func, 500, true)
-      const { clear } = debouncedFunc()
       debouncedFunc()
-      clear()
+      debouncedFunc()
       expect(func).toHaveBeenCalledTimes(1)
     })
 
     it("immediate = true. does invoke the function again before time has passed if cleared", () => {
       const func = jest.fn()
       const debouncedFunc = _.debounce(func, 500, true)
-      const { clear } = debouncedFunc()
-      clear()
+      debouncedFunc()
+      debouncedFunc.clear()
       debouncedFunc()
       expect(func).toHaveBeenCalledTimes(2)
     })
 
-    it("immediate = true. return object includes result", () => {
+    it("immediate = true. returns a promise that resolves to result", async () => {
       const func = jest.fn(() => 4)
       const debouncedFunc = _.debounce(func, 500, true)
-      const { result } = debouncedFunc()
-      debouncedFunc()
+      const result = await debouncedFunc()
       expect(result).toBe(4)
     })
 
@@ -1159,18 +1157,16 @@ describe("misc", () => {
     it("immediate = false. flush executes the function immediately", async () => {
       const func = jest.fn()
       const debouncedFunc = _.debounce(func, 500, false)
-      const { flush } = debouncedFunc()
-      flush()
+      debouncedFunc()
+      debouncedFunc.flush()
       expect(func).toHaveBeenCalledTimes(1)
     })
 
-    it("immediate = false. result updates after pause", async () => {
+    it("immediate = false. returns a promise that resolves after delay", async () => {
       const func = jest.fn(() => 4)
       const debouncedFunc = _.debounce(func, 500, false)
-      const returnObject = debouncedFunc()
-      setTimeout(() => {
-        expect(returnObject.result).toBe(4)
-      }, 1000)
+      const result = await debouncedFunc()
+      expect(result).toBe(4)
     })
   })
 

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -978,7 +978,7 @@ describe("objects", () => {
 })
 
 describe("misc", () => {
-  describe("addTimeoutToPromise", () => {
+  describe("withTimeout", () => {
     it("throws an error if timeout happens first", async () => {
       let err = ""
       let timer
@@ -986,7 +986,7 @@ describe("misc", () => {
         new Promise((resolve, reject) => {
           timer = setTimeout(resolve, 500)
         })
-      const slowThingWithTimeout = _.addTimeoutToPromise(slowThing, 200)
+      const slowThingWithTimeout = _.withTimeout(slowThing, 200)
       try {
         await slowThingWithTimeout()
       } catch (e) {
@@ -1004,7 +1004,7 @@ describe("misc", () => {
         new Promise((resolve, reject) => {
           timer = setTimeout(() => resolve("DONE"), 200)
         })
-      const slowThingWithTimeout = _.addTimeoutToPromise(fastThing, 500)
+      const slowThingWithTimeout = _.withTimeout(fastThing, 500)
       try {
         result = await slowThingWithTimeout()
       } catch (e) {

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -93,10 +93,12 @@ describe("time & dates", () => {
       then.setMinutes(then.getMinutes() - 3)
       then.setSeconds(then.getSeconds() - 4)
 
-      const fnResult = _.getDateFromDuration(
-        { days: 1, hours: 2, minutes: 3, seconds: 4 },
-        "past"
-      )
+      const fnResult = _.getDateFromDuration({
+        days: -1,
+        hours: -2,
+        minutes: -3,
+        seconds: -4,
+      })
 
       expect(fnResult.getDate()).toBe(then.getDate())
       expect(fnResult.getHours()).toBe(then.getHours())
@@ -112,10 +114,12 @@ describe("time & dates", () => {
       then.setMinutes(then.getMinutes() + 3)
       then.setSeconds(then.getSeconds() + 4)
 
-      const fnResult = _.getDateFromDuration(
-        { days: 1, hours: 2, minutes: 3, seconds: 4 },
-        "future"
-      )
+      const fnResult = _.getDateFromDuration({
+        days: 1,
+        hours: 2,
+        minutes: 3,
+        seconds: 4,
+      })
 
       expect(fnResult.getDate()).toBe(then.getDate())
       expect(fnResult.getHours()).toBe(then.getHours())

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -978,42 +978,42 @@ describe("objects", () => {
 })
 
 describe("misc", () => {
-  describe("withTimeout", () => {
-    it("throws an error if timeout happens first", async () => {
-      let err = ""
-      let timer
-      const slowThing = async () =>
-        new Promise((resolve, reject) => {
-          timer = setTimeout(resolve, 500)
-        })
-      const slowThingWithTimeout = _.withTimeout(slowThing, 200)
-      try {
-        await slowThingWithTimeout()
-      } catch (e) {
-        clearTimeout(timer)
-        err = e as string
-      }
-      expect(err).toBe("TIMED_OUT")
-    })
+  // describe("withTimeout", () => {
+  //   it("throws an error if timeout happens first", async () => {
+  //     let err = ""
+  //     let timer
+  //     const slowThing = async () =>
+  //       new Promise((resolve, reject) => {
+  //         timer = setTimeout(resolve, 500)
+  //       })
+  //     const slowThingWithTimeout = _.withTimeout(slowThing, 200)
+  //     try {
+  //       await slowThingWithTimeout()
+  //     } catch (e) {
+  //       clearTimeout(timer)
+  //       err = e as string
+  //     }
+  //     expect(err).toBe("TIMED_OUT")
+  //   })
 
-    it("returns the promise result if promise resolves happens first", async () => {
-      let result
-      let err = ""
-      let timer
-      const fastThing = async () =>
-        new Promise((resolve, reject) => {
-          timer = setTimeout(() => resolve("DONE"), 200)
-        })
-      const slowThingWithTimeout = _.withTimeout(fastThing, 500)
-      try {
-        result = await slowThingWithTimeout()
-      } catch (e) {
-        clearTimeout(timer)
-        err = e as string
-      }
-      expect(result as string).toBe("DONE")
-    })
-  })
+  //   it("returns the promise result if promise resolves happens first", async () => {
+  //     let result
+  //     let err = ""
+  //     let timer
+  //     const fastThing = async () =>
+  //       new Promise((resolve, reject) => {
+  //         timer = setTimeout(() => resolve("DONE"), 200)
+  //       })
+  //     const slowThingWithTimeout = _.withTimeout(fastThing, 500)
+  //     try {
+  //       result = await slowThingWithTimeout()
+  //     } catch (e) {
+  //       clearTimeout(timer)
+  //       err = e as string
+  //     }
+  //     expect(result as string).toBe("DONE")
+  //   })
+  // })
 
   describe("pauseAsync", () => {
     it("pauses for the provided milliseconds", async () => {
@@ -1133,6 +1133,14 @@ describe("misc", () => {
       expect(result).toBe(4)
     })
 
+    it("immediate = true. flush does not execute the function", async () => {
+      const func = jest.fn()
+      const debouncedFunc = _.debounce(func, 500, true)
+      debouncedFunc()
+      debouncedFunc.flush()
+      expect(func).toHaveBeenCalledTimes(1)
+    })
+
     it("immediate = false. invokes the function after the delay but not before", async () => {
       const func = jest.fn()
       const debouncedFunc = _.debounce(func, 200, false)
@@ -1158,6 +1166,25 @@ describe("misc", () => {
       const func = jest.fn()
       const debouncedFunc = _.debounce(func, 500, false)
       debouncedFunc()
+      debouncedFunc.flush()
+      expect(func).toHaveBeenCalledTimes(1)
+    })
+
+    it("immediate = false. flush only executes once", async () => {
+      const func = jest.fn()
+      const debouncedFunc = _.debounce(func, 500, false)
+      debouncedFunc()
+      debouncedFunc.flush()
+      debouncedFunc.flush()
+      expect(func).toHaveBeenCalledTimes(1)
+    })
+
+    it("immediate = false. flush does not execute function if no calls pending", async () => {
+      const func = jest.fn()
+      const debouncedFunc = _.debounce(func, 500, false)
+
+      debouncedFunc()
+      await _.pauseAsync(600)
       debouncedFunc.flush()
       expect(func).toHaveBeenCalledTimes(1)
     })

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -1015,10 +1015,10 @@ describe("misc", () => {
     })
   })
 
-  describe("pauseAsync", () => {
+  describe("pause", () => {
     it("pauses for the provided milliseconds", async () => {
       const start = Date.now()
-      await _.pauseAsync(200)
+      await _.pause(200)
       const end = Date.now()
       expect(end - start).toBeGreaterThanOrEqual(199)
     })
@@ -1146,7 +1146,7 @@ describe("misc", () => {
       const debouncedFunc = _.debounce(func, 100, false)
       debouncedFunc()
       expect(func).toHaveBeenCalledTimes(0)
-      await _.pauseAsync(200)
+      await _.pause(200)
       expect(func).toHaveBeenCalledTimes(1)
     })
 
@@ -1156,9 +1156,9 @@ describe("misc", () => {
       debouncedFunc()
       debouncedFunc()
       expect(func).toHaveBeenCalledTimes(0)
-      await _.pauseAsync(100)
+      await _.pause(100)
       expect(func).toHaveBeenCalledTimes(0)
-      await _.pauseAsync(300)
+      await _.pause(300)
       expect(func).toHaveBeenCalledTimes(1)
     })
 
@@ -1184,7 +1184,7 @@ describe("misc", () => {
       const debouncedFunc = _.debounce(func, 100, false)
 
       debouncedFunc()
-      await _.pauseAsync(200)
+      await _.pause(200)
       debouncedFunc.flush()
       expect(func).toHaveBeenCalledTimes(1)
     })
@@ -1210,7 +1210,7 @@ describe("misc", () => {
       const func = jest.fn()
       const throttledFunc = _.throttle(func, 100)
       throttledFunc()
-      await _.pauseAsync(200)
+      await _.pause(200)
       throttledFunc()
       expect(func).toHaveBeenCalledTimes(2)
     })
@@ -1220,7 +1220,7 @@ describe("misc", () => {
       const throttledFunc = _.throttle(func, 100)
       throttledFunc()
       throttledFunc()
-      await _.pauseAsync(300)
+      await _.pause(300)
       expect(func).toHaveBeenCalledTimes(2)
     })
   })

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -192,7 +192,7 @@ describe("time & dates", () => {
     })
   })
 
-  describe("getDurationBetweenDates", () => {
+  describe("getDuration", () => {
     it("returns the correct duration", () => {
       const start = new Date()
       const end = new Date(start)
@@ -978,60 +978,60 @@ describe("objects", () => {
 })
 
 describe("misc", () => {
-  // describe("withTimeout", () => {
-  //   it("throws an error if timeout happens first", async () => {
-  //     let err = ""
-  //     let timer
-  //     const slowThing = async () =>
-  //       new Promise((resolve, reject) => {
-  //         timer = setTimeout(resolve, 500)
-  //       })
-  //     const slowThingWithTimeout = _.withTimeout(slowThing, 200)
-  //     try {
-  //       await slowThingWithTimeout()
-  //     } catch (e) {
-  //       clearTimeout(timer)
-  //       err = e as string
-  //     }
-  //     expect(err).toBe("TIMED_OUT")
-  //   })
+  describe("withTimeout", () => {
+    it("throws an error if timeout happens first", async () => {
+      let err = ""
+      let timer
+      const slowThing = async () =>
+        new Promise((resolve, reject) => {
+          timer = setTimeout(resolve, 200)
+        })
+      const slowThingWithTimeout = _.withTimeout(slowThing, 100)
+      try {
+        await slowThingWithTimeout()
+      } catch (e) {
+        clearTimeout(timer)
+        err = e as string
+      }
+      expect(err).toBe("TIMED_OUT")
+    })
 
-  //   it("returns the promise result if promise resolves happens first", async () => {
-  //     let result
-  //     let err = ""
-  //     let timer
-  //     const fastThing = async () =>
-  //       new Promise((resolve, reject) => {
-  //         timer = setTimeout(() => resolve("DONE"), 200)
-  //       })
-  //     const slowThingWithTimeout = _.withTimeout(fastThing, 500)
-  //     try {
-  //       result = await slowThingWithTimeout()
-  //     } catch (e) {
-  //       clearTimeout(timer)
-  //       err = e as string
-  //     }
-  //     expect(result as string).toBe("DONE")
-  //   })
-  // })
+    it("returns the promise result if promise resolves happens first", async () => {
+      let result
+      let err = ""
+      let timer
+      const fastThing = async () =>
+        new Promise((resolve, reject) => {
+          timer = setTimeout(() => resolve("DONE"), 100)
+        })
+      const slowThingWithTimeout = _.withTimeout(fastThing, 200)
+      try {
+        result = await slowThingWithTimeout()
+      } catch (e) {
+        clearTimeout(timer)
+        err = e as string
+      }
+      expect(result as string).toBe("DONE")
+    })
+  })
 
   describe("pauseAsync", () => {
     it("pauses for the provided milliseconds", async () => {
       const start = Date.now()
-      await _.pauseAsync(500)
+      await _.pauseAsync(200)
       const end = Date.now()
-      expect(end - start).toBeGreaterThanOrEqual(499)
+      expect(end - start).toBeGreaterThanOrEqual(199)
     })
   })
 
-  describe("pauseSync", () => {
-    it("pauses for the provided milliseconds", () => {
-      const start = Date.now()
-      _.pauseSync(500)
-      const end = Date.now()
-      expect(end - start).toBeGreaterThanOrEqual(500)
-    })
-  })
+  // describe("pauseSync", () => {
+  //   it("pauses for the provided milliseconds", () => {
+  //     const start = Date.now()
+  //     _.pauseSync(500)
+  //     const end = Date.now()
+  //     expect(end - start).toBeGreaterThanOrEqual(500)
+  //   })
+  // })
 
   describe("pipe", () => {
     it("creates a pipe function", () => {
@@ -1104,14 +1104,14 @@ describe("misc", () => {
   describe("debounce", () => {
     it("immediate = true. invokes the function immediately on first call", () => {
       const func = jest.fn()
-      const debouncedFunc = _.debounce(func, 200, true)
+      const debouncedFunc = _.debounce(func, 100, true)
       debouncedFunc()
       expect(func).toHaveBeenCalled()
     })
 
     it("immediate = true. does not invoke the function again before time has passed", () => {
       const func = jest.fn()
-      const debouncedFunc = _.debounce(func, 500, true)
+      const debouncedFunc = _.debounce(func, 200, true)
       debouncedFunc()
       debouncedFunc()
       expect(func).toHaveBeenCalledTimes(1)
@@ -1119,7 +1119,7 @@ describe("misc", () => {
 
     it("immediate = true. does invoke the function again before time has passed if cleared", () => {
       const func = jest.fn()
-      const debouncedFunc = _.debounce(func, 500, true)
+      const debouncedFunc = _.debounce(func, 200, true)
       debouncedFunc()
       debouncedFunc.clear()
       debouncedFunc()
@@ -1128,14 +1128,14 @@ describe("misc", () => {
 
     it("immediate = true. returns a promise that resolves to result", async () => {
       const func = jest.fn(() => 4)
-      const debouncedFunc = _.debounce(func, 500, true)
+      const debouncedFunc = _.debounce(func, 100, true)
       const result = await debouncedFunc()
       expect(result).toBe(4)
     })
 
     it("immediate = true. flush does not execute the function", async () => {
       const func = jest.fn()
-      const debouncedFunc = _.debounce(func, 500, true)
+      const debouncedFunc = _.debounce(func, 100, true)
       debouncedFunc()
       debouncedFunc.flush()
       expect(func).toHaveBeenCalledTimes(1)
@@ -1143,20 +1143,20 @@ describe("misc", () => {
 
     it("immediate = false. invokes the function after the delay but not before", async () => {
       const func = jest.fn()
-      const debouncedFunc = _.debounce(func, 200, false)
+      const debouncedFunc = _.debounce(func, 100, false)
       debouncedFunc()
       expect(func).toHaveBeenCalledTimes(0)
-      await _.pauseAsync(500)
+      await _.pauseAsync(200)
       expect(func).toHaveBeenCalledTimes(1)
     })
 
     it("immediate = false. restarts the delay if the function is tried before the wait has passed", async () => {
       const func = jest.fn()
-      const debouncedFunc = _.debounce(func, 500, false)
+      const debouncedFunc = _.debounce(func, 200, false)
       debouncedFunc()
       debouncedFunc()
       expect(func).toHaveBeenCalledTimes(0)
-      await _.pauseAsync(200)
+      await _.pauseAsync(100)
       expect(func).toHaveBeenCalledTimes(0)
       await _.pauseAsync(300)
       expect(func).toHaveBeenCalledTimes(1)
@@ -1164,7 +1164,7 @@ describe("misc", () => {
 
     it("immediate = false. flush executes the function immediately", async () => {
       const func = jest.fn()
-      const debouncedFunc = _.debounce(func, 500, false)
+      const debouncedFunc = _.debounce(func, 100, false)
       debouncedFunc()
       debouncedFunc.flush()
       expect(func).toHaveBeenCalledTimes(1)
@@ -1172,7 +1172,7 @@ describe("misc", () => {
 
     it("immediate = false. flush only executes once", async () => {
       const func = jest.fn()
-      const debouncedFunc = _.debounce(func, 500, false)
+      const debouncedFunc = _.debounce(func, 100, false)
       debouncedFunc()
       debouncedFunc.flush()
       debouncedFunc.flush()
@@ -1181,26 +1181,26 @@ describe("misc", () => {
 
     it("immediate = false. flush does not execute function if no calls pending", async () => {
       const func = jest.fn()
-      const debouncedFunc = _.debounce(func, 500, false)
+      const debouncedFunc = _.debounce(func, 100, false)
 
       debouncedFunc()
-      await _.pauseAsync(600)
+      await _.pauseAsync(200)
       debouncedFunc.flush()
       expect(func).toHaveBeenCalledTimes(1)
     })
 
     it("immediate = false. returns a promise that resolves after delay", async () => {
       const func = jest.fn(() => 4)
-      const debouncedFunc = _.debounce(func, 500, false)
+      const debouncedFunc = _.debounce(func, 100, false)
       const result = await debouncedFunc()
       expect(result).toBe(4)
     })
   })
 
   describe("throttle", () => {
-    it("will not execute a function more than once in the alloted time", () => {
+    it("will not execute a function more than once in the alloted time", async () => {
       const func = jest.fn()
-      const throttledFunc = _.throttle(func, 2000)
+      const throttledFunc = _.throttle(func, 100)
       throttledFunc()
       throttledFunc()
       expect(func).toHaveBeenCalledTimes(1)

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -1185,29 +1185,20 @@ describe("misc", () => {
 
     it("executes a function again after the alloted time", async () => {
       const func = jest.fn()
-      const throttledFunc = _.throttle(func, 100, false)
+      const throttledFunc = _.throttle(func, 100)
       throttledFunc()
       await _.pauseAsync(200)
       throttledFunc()
       expect(func).toHaveBeenCalledTimes(2)
     })
 
-    it("enqueues early requests by default", async () => {
+    it("enqueues early requests", async () => {
       const func = jest.fn()
       const throttledFunc = _.throttle(func, 100)
       throttledFunc()
       throttledFunc()
       await _.pauseAsync(300)
       expect(func).toHaveBeenCalledTimes(2)
-    })
-
-    it("ignores early requests if enqueueEarlyCalls is false", async () => {
-      const func = jest.fn()
-      const throttledFunc = _.throttle(func, 100, false)
-      throttledFunc()
-      throttledFunc()
-      await _.pauseAsync(300)
-      expect(func).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/gladney.ts
+++ b/gladney.ts
@@ -1826,12 +1826,9 @@ export function debounce<T extends (...args: any[]) => any>(
 }
 
 /** Returns a throttled version of a function. The throttled version can only execute once every N milliseconds,
- * where N is the delay passed in to the throttle function.
- *
- * An optional third parameter indicates whether subsequent calls of the function before the
- * delay period has passed should be enqueued and run once the delay passes (true)
- * or simply ignored (false). The default is true.
- *
+ * where N is the delay passed in to the throttle function. If the function is called again before the necessary
+ * time has passed since last calling the function, the subsequent execution is queued and will occur
+ * once the time has passed.
  **/
 export function throttle<
   T extends Func | AsyncFunc,

--- a/gladney.ts
+++ b/gladney.ts
@@ -1744,21 +1744,22 @@ export function convertQueryParamOperators(params: {}) {
 /** Takes a promise and wraps it in another promise that rejects if the original promise takes longer to resolve than a
  * specific amount of time in milliseconds. If the original promise resolves before the timeout, that value is returned.
  **/
-export function withTimeout<T>(
-  asyncFunction: () => Promise<T>,
-  timeout: number
-) {
-  return () =>
+export function withTimeout<
+  T extends Func,
+  U extends Parameters<T>,
+  V extends ReturnType<T>
+>(asyncFunction: T, timeout: number) {
+  return (...args: U) =>
     new Promise((resolve, reject) => {
       let timer: NodeJS.Timeout
-      asyncFunction().then((result) => {
+      asyncFunction().then((result: V) => {
         clearTimeout(timer)
         resolve(result)
       })
       timer = setTimeout(() => {
         reject("TIMED_OUT")
       }, timeout)
-    }) as Promise<T>
+    }) as V
 }
 
 /** Returns a promise that resolves after a given amount of time in milliseconds.

--- a/gladney.ts
+++ b/gladney.ts
@@ -696,7 +696,7 @@ export function isNumeric(n: string | number) {
  * ```
  */
 
-export function shave<T extends string | U[], U>(
+export function shave<T extends string | any[]>(
   iterable: T,
   n: number
 ): StringOrArray<T> {

--- a/gladney.ts
+++ b/gladney.ts
@@ -93,13 +93,13 @@ export function doubleDigit(n: number) {
 export function range(start: number, end: number, step = 1) {
   const result: number[] = []
   if (start < end) {
-    if (step <= 0) return
+    if (step <= 0) return result
     for (let i = start; i <= end; i += step) {
       result.push(i)
     }
   } else {
     if (step === 1) step = -1
-    else if (step >= 0) return
+    else if (step >= 0) return result
     else {
       for (let i = start; i >= end; i += step) {
         result.push(i)
@@ -187,32 +187,15 @@ const secondsInAMinute = 60
 const secondsInAnHour = 3600
 const secondsInADay = 86400
 
-/** Returns a `TimeObject` with calculated days, hours, minutes and seconds from an amount of seconds.
+/** Returns a `Duration` with calculated days, hours, minutes and seconds from an amount of seconds.
  *
  * _Example:_
  * ```typescript
  * getDurationFromMilliseconds(200000000)
 //=> { days: 2, hours: 7, minutes: 33, seconds: 20 }
-
-interface TimeObject {
-  years: number
-  months: number
-  weeks: number
-  days: number
-  hours: number
-  minutes: number
-  seconds: number
-  inYears: () => number
-  inMonths: () => number
-  inWeeks: () => number
-  inDays: () => number
-  inHours: () => number
-  inMinutes: () => number
-  inSeconds: () => number
-}
  * ```
  **/
-function getDurationFromMilliseconds(milliseconds: number): TimeObject {
+function getDurationFromMilliseconds(milliseconds: number): Duration {
   const seconds = Math.floor(milliseconds / 1000)
 
   return {
@@ -233,7 +216,7 @@ function getDurationFromMilliseconds(milliseconds: number): TimeObject {
  * getMillisecondsFromDuration(amountOfTime) //=> 98651000
  * ```
  */
-function getMillisecondsFromDuration(duration: Partial<TimeObject>) {
+function getMillisecondsFromDuration(duration: Partial<Duration>) {
   let result = 0
   if (duration.days) result += duration.days * secondsInADay * 1000
   if (duration.hours) result += duration.hours * secondsInAnHour * 1000
@@ -258,20 +241,16 @@ function getMillisecondsFromDuration(duration: Partial<TimeObject>) {
  * ```
  */
 export function getDateFromDuration(
-  duration: Partial<TimeObject>,
-  inThe: "past" | "future",
+  duration: Partial<Duration>,
   startDate: Date = new Date()
 ) {
-  const ms = getMillisecondsFromDuration(duration)
-  return inThe === "future"
-    ? new Date(startDate.getTime() + ms)
-    : new Date(startDate.getTime() - ms)
+  return new Date(startDate.getTime() + getMillisecondsFromDuration(duration))
 }
 
-/** Returns a `TimeObject` with the number of years, months, weeks, days, hours, minutes and seconds until 
- * a specific date. A `TimeObject` also includes methods to measure the amount of time in a specific unit (i.e. minutes)
+/** Returns a `Duration` with the number of years, months, weeks, days, hours, minutes and seconds until 
+ * a specific date. A `Duration` also includes methods to measure the amount of time in a specific unit (i.e. minutes)
  * ```typescript
-interface TimeObject {
+interface Duration {
   days: number
   hours: number
   minutes: number
@@ -280,14 +259,14 @@ interface TimeObject {
  * ```
  **/
 
-export function timeUntil(date: Date): TimeObject {
+export function timeUntil(date: Date): Duration {
   return getDuration(new Date(), new Date(date))
 }
 
-/** Returns a `TimeObject` with the number of years, months, weeks, days, hours, minutes and seconds since a
- * specific date. A `TimeObject` also includes methods to measure the amount of time in a specific unit (i.e. minutes)
+/** Returns a `Duration` with the number of years, months, weeks, days, hours, minutes and seconds since a
+ * specific date. A `Duration` also includes methods to measure the amount of time in a specific unit (i.e. minutes)
  * ```typescript
-interface TimeObject {
+interface Duration {
   days: number
   hours: number
   minutes: number
@@ -295,7 +274,7 @@ interface TimeObject {
 }
  * ```
  **/
-export function timeSince(date: Date): TimeObject {
+export function timeSince(date: Date): Duration {
   return getDuration(new Date(), new Date(date))
 }
 
@@ -341,7 +320,7 @@ export function isPast(date: Date) {
   return new Date(date).getTime() < Date.now()
 }
 
-/** Returns a TimeObject representing the amount of time between two dates.
+/** Returns a Duration representing the amount of time between two dates.
  *
  * Example:
  *
@@ -2216,7 +2195,7 @@ export function stripHTML(text: string) {
 
 // TYPES
 
-export interface TimeObject {
+export interface Duration {
   days: number
   hours: number
   minutes: number

--- a/gladney.ts
+++ b/gladney.ts
@@ -1597,9 +1597,9 @@ export function getKeyWithLargestValue<T extends object>(obj: T) {
  * getKeyWhereValueIs(obj, 3) //=> "c"
  * ```
  */
-export function getKeyWhereValueIs<T extends object>(
+export function getKeyWhereValueIs<T extends object, U extends T[keyof T]>(
   obj: T,
-  value: any
+  value: U
 ): string | null {
   for (let key in obj) {
     if (obj[key] === value) return key

--- a/gladney.ts
+++ b/gladney.ts
@@ -2048,7 +2048,7 @@ export function setCookie(
 }
 
 type Queue<T extends Func> = {
-  queue: unknown[]
+  queue: Parameters<T>[]
   enqueue: (...args: Parameters<T>) => void
   executeOne: Function
   executeAll: (ignoreErrors?: boolean) => unknown
@@ -2070,7 +2070,7 @@ export function createQueue<T extends Func>(
   functionToExecute: T,
   delay?: number
 ): Queue<T> {
-  const queue: unknown[][] = []
+  const queue: Parameters<T>[] = []
   let isBreakRequested = false
   const executeOne = async () => {
     await functionToExecute(...(queue[0] as T[]))
@@ -2096,7 +2096,7 @@ export function createQueue<T extends Func>(
       isBreakRequested = true
     },
     queue,
-    enqueue: (...args: T[]) => queue.push(args),
+    enqueue: (...args: Parameters<T>) => queue.push(args),
     executeOne,
     executeAll,
   }

--- a/gladney.ts
+++ b/gladney.ts
@@ -1897,9 +1897,8 @@ export function debounce<T extends (...args: any[]) => any>(
  **/
 
 type Func = (...args: any[]) => any
-type AsyncFunc = (...args: any[]) => Promise<any>
 
-export function throttle<T extends Func | AsyncFunc>(
+export function throttle<T extends Func>(
   func: T,
   delay: number,
   enqueueEarlyCalls = true
@@ -2048,7 +2047,7 @@ export function setCookie(
   document.cookie = cookieName + "=" + cookieValue + ";" + expires + ";"
 }
 
-type Queue<T extends Func | AsyncFunc> = {
+type Queue<T extends Func> = {
   queue: unknown[]
   enqueue: (...args: Parameters<T>) => void
   executeOne: Function
@@ -2061,13 +2060,13 @@ type Queue<T extends Func | AsyncFunc> = {
  * requests are not initiated until prior requests have completed.
  *
  */
-export function withQueue(fn: AsyncFunc): AsyncFunc {
+export function withQueue<T extends Func>(fn: T): T {
   return throttle(fn, 0)
 }
 
 /** Returns an `Queue` which includes a queue, enqueue function, and two execute methods.
  **/
-export function createQueue<T extends AsyncFunc>(
+export function createQueue<T extends Func>(
   functionToExecute: T,
   delay?: number
 ): Queue<T> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gladknee",
-  "version": "1.4.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gladknee",
-      "version": "1.4.0",
+      "version": "1.7.1",
       "license": "ISC",
       "devDependencies": {
         "@types/express": "^4.17.17",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gladknee",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "description": "A zero-dependency utility library written in TypeScript",
   "main": "dist/gladney.js",
   "types": "dist/gladney.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gladknee",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "A zero-dependency utility library written in TypeScript",
   "main": "dist/gladney.js",
   "types": "dist/gladney.d.ts",


### PR DESCRIPTION
- Add stronger typing to `getKeyWhereValueIs`
- Rename `AsyncQueueObject` to `Queue` and `createAsyncQueueObject` to `createQueue`
- Rename `addTimeoutToPromise` to `withTimeout`
- Improve type inference of `createQueue`
- Rename `pauseAsync` to `pause`
- Remove `pauseSync`
- Rename `TimeObject` to `Duration`
- Remove `inThe` param from `getDateFromDuration` and rely on negative numbers instead

### Major change: `debounce`

Previously, the debounced function...

1. When executed, returned an object with `clear`, `flush`, and `result` properties.

Now, the debounced function...

1. When executed, returns a promise that resolves to the return value of the function once executed or undefined if function is not run
2. Still contains `clear` and `flush` methods
3. Has a smarter flush method (does not execute function if no pending execution)

### Dev updates

- Fix tests so there's not pending async operations
- Move all types to bottom of file