### PR TITLE
v1.8.2 Object safe array comparison methods

### DIFF
--- a/gladney.ts
+++ b/gladney.ts
@@ -1000,18 +1000,21 @@ export function getUniqueItems<T>(...arrs: T[][]) {
  * ```
  * See also: `getUniqueItems()` and `getSharedItems()`
  **/
-export function getCommonItems<T>(...arrs: T[][]) {
-  const seen: T[] = []
-  let result: T[] = []
-  for (let i = 0; i < arrs.length; i++) {
-    arrs[i].forEach((j) => {
+export function getCommonItems<T>(...arrays: T[][]) {
+  const arraysAsJSONStrings = arrays.map((arr) =>
+    arr.map((item) => JSON.stringify(item))
+  )
+  const seen: string[] = []
+  let result: string[] = []
+  for (let i = 0; i < arrays.length; i++) {
+    arraysAsJSONStrings[i].forEach((j) => {
       if (seen.includes(j) && !result.includes(j)) {
         result.push(j)
       }
       seen.push(j)
     })
   }
-  return result
+  return result.map((item) => JSON.parse(item)) as T[]
 }
 
 /** Returns an array of items that appear in all of the given arrays.
@@ -1027,8 +1030,8 @@ export function getCommonItems<T>(...arrs: T[][]) {
  * See also: `getUniqueItems()` and `getCommonItems()`
  **/
 export function getSharedItems<T>(firstArray: T[], ...otherArrays: T[][]) {
-  const firstArrayAsJSONString = firstArray.map((item) => JSON.stringify(item))
-  const firstArrayUniqueValues = Array.from(new Set(firstArrayAsJSONString))
+  const firstArrayAsJSONStrings = firstArray.map((item) => JSON.stringify(item))
+  const firstArrayUniqueValues = Array.from(new Set(firstArrayAsJSONStrings))
 
   return otherArrays
     .reduce((acc, arr) => {

--- a/gladney.ts
+++ b/gladney.ts
@@ -1043,7 +1043,7 @@ export function getSharedItems<T>(firstArray: T[], ...otherArrays: T[][]) {
       const arrayAsJSONString = arr.map((item) => JSON.stringify(item))
       return acc.filter((item) => arrayAsJSONString.includes(item))
     }, firstArrayUniqueValues)
-    .map((item) => JSON.parse(item))
+    .map((item) => JSON.parse(item)) as T[]
 }
 
 /** Returns the provided array with two items' positions swapped

--- a/gladney.ts
+++ b/gladney.ts
@@ -1026,16 +1026,16 @@ export function getCommonItems<T>(...arrs: T[][]) {
  * ```
  * See also: `getUniqueItems()` and `getCommonItems()`
  **/
-export function getSharedItems<T>(...arrs: T[][]) {
-  let result: T[] = []
-  arrs[0].forEach((item) => {
-    let isItemInAllOtherArrays = true
-    arrs.slice(1).forEach((compareArray) => {
-      if (!compareArray.includes(item)) isItemInAllOtherArrays = false
-    })
-    if (isItemInAllOtherArrays) result.push(item)
-  })
-  return result
+export function getSharedItems<T>(firstArray: T[], ...otherArrays: T[][]) {
+  const firstArrayAsJSONString = firstArray.map((item) => JSON.stringify(item))
+  const firstArrayUniqueValues = Array.from(new Set(firstArrayAsJSONString))
+
+  return otherArrays
+    .reduce((acc, arr) => {
+      const arrayAsJSONString = arr.map((item) => JSON.stringify(item))
+      return acc.filter((item) => arrayAsJSONString.includes(item))
+    }, firstArrayUniqueValues)
+    .map((item) => JSON.parse(item))
 }
 
 /** Returns the provided array with two items' positions swapped

--- a/gladney.ts
+++ b/gladney.ts
@@ -971,12 +971,16 @@ export function getCount<T>(arr: T[], target: T) {
  * ```
  * See also: `getCommonItems()` and `getSharedItems()`
  **/
-export function getUniqueItems<T>(...arrs: T[][]) {
-  const seen: T[] = []
-  let result: T[] = []
-  const sets = arrs.map((arr) => new Set(arr))
-  for (let i = 0; i < sets.length; i++) {
-    sets[i].forEach((j) => {
+export function getUniqueItems<T>(firstArray: T[], ...otherArrays: T[][]) {
+  const arraysAsJSONStrings = [firstArray, ...otherArrays].map((arr) =>
+    arr.map((item: T) => JSON.stringify(item))
+  )
+  const arraysUniqueValues = arraysAsJSONStrings.map((arr) => new Set(arr))
+  const seen: string[] = []
+  let result: string[] = []
+
+  for (let i = 0; i < arraysUniqueValues.length; i++) {
+    arraysUniqueValues[i].forEach((j) => {
       if (seen.includes(j)) {
         result = result.filter((x) => x !== j)
       } else {
@@ -985,7 +989,7 @@ export function getUniqueItems<T>(...arrs: T[][]) {
       }
     })
   }
-  return result
+  return result.map((item) => JSON.parse(item)) as T[]
 }
 
 /** Returns an array of items that appear in at least two of the given arrays.
@@ -1000,13 +1004,14 @@ export function getUniqueItems<T>(...arrs: T[][]) {
  * ```
  * See also: `getUniqueItems()` and `getSharedItems()`
  **/
-export function getCommonItems<T>(...arrays: T[][]) {
-  const arraysAsJSONStrings = arrays.map((arr) =>
-    arr.map((item) => JSON.stringify(item))
+export function getCommonItems<T>(firstArray: T[], ...otherArrays: T[][]) {
+  const arraysAsJSONStrings = [firstArray, ...otherArrays].map((arr) =>
+    arr.map((item: T) => JSON.stringify(item))
   )
   const seen: string[] = []
   let result: string[] = []
-  for (let i = 0; i < arrays.length; i++) {
+
+  for (let i = 0; i < arraysAsJSONStrings.length; i++) {
     arraysAsJSONStrings[i].forEach((j) => {
       if (seen.includes(j) && !result.includes(j)) {
         result.push(j)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gladknee",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "A zero-dependency utility library written in TypeScript",
   "main": "dist/gladney.js",
   "types": "dist/gladney.d.ts",


### PR DESCRIPTION
This PR updates the three array comparison methods to use stringified JSON so that the functions work with arrays of objects. It also updates the function call signatures to require two or more arrays be passed in as arguments. Lastly, the `getSharedItems` function has been re-written to handle duplicates in the initial array and to be a bit more terse.

`getUniqueItems()`
`getSharedItems()`
`getCommonItems()`