### PR TITLE
April 2024

### DIFF
--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -419,6 +419,19 @@ describe("arrays", () => {
         Jane: "Smith",
       })
     })
+
+    it("can use the index in the callback", () => {
+      const arr = [
+        { first: "John", last: "Doe" },
+        { first: "Jane", last: "Smith" },
+      ]
+      expect(
+        _.arrayInto(arr, (i, index) => ({ [String(index)]: i.last }))
+      ).toEqual({
+        "0": "Doe",
+        "1": "Smith",
+      })
+    })
   })
 
   describe("shuffle", () => {

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -407,6 +407,20 @@ describe("arrays", () => {
       expect(_.repeatArray([1, 2, 3], 3)).toEqual([1, 2, 3, 1, 2, 3, 1, 2, 3])
     })
   })
+
+  describe("arrayInto", () => {
+    it("converts the array into the proper object", () => {
+      const arr = [
+        { first: "John", last: "Doe" },
+        { first: "Jane", last: "Smith" },
+      ]
+      expect(_.arrayInto(arr, (i) => ({ [i.first]: i.last }))).toEqual({
+        John: "Doe",
+        Jane: "Smith",
+      })
+    })
+  })
+
   describe("shuffle", () => {
     it("returns the array in a different order", () => {
       const arr = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
@@ -713,11 +727,11 @@ describe("objects", () => {
     })
   })
 
-  describe("into", () => {
+  describe("objectInto", () => {
     it("returns the desired new shape", () => {
       const obj = { user: { name: "Stephen", age: 39, sex: "M" } }
       expect(
-        _.into(obj, (key, value) => ({ [value.name]: value.age }))
+        _.objectInto(obj, (key, value) => ({ [value.name]: value.age }))
       ).toEqual({ Stephen: 39 })
     })
   })

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -267,6 +267,18 @@ describe("strings", () => {
     })
   })
 
+  describe("lazyIncludes", () => {
+    it("returns true if the characters are present", () => {
+      expect(_.lazyIncludes("Hello world", "LL")).toBeTruthy()
+      expect(_.lazyIncludes("Hello world", "ll")).toBeTruthy()
+    })
+
+    it("returns false if the characters are present", () => {
+      expect(_.lazyIncludes("Hello world", "f")).toBeFalsy()
+      expect(_.lazyIncludes("Hello world", "F")).toBeFalsy()
+    })
+  })
+
   describe("truncate", () => {
     it("enforces the maximum length and uses traililng by default", () => {
       expect(_.truncate("Hello world", 8)).toBe("Hello wo...")

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -83,6 +83,57 @@ describe("time & dates", () => {
   // })
 
   describe("getDateFromDuration", () => {
+    const now = new Date("1/1/2024")
+    it("returns the correct date in the future", () => {
+      const then = new Date(now)
+
+      then.setDate(then.getDate() + 1)
+      then.setHours(then.getHours() + 2)
+      then.setMinutes(then.getMinutes() + 3)
+      then.setSeconds(then.getSeconds() + 4)
+
+      const fnResult = _.getDateFromDuration(
+        {
+          days: 1,
+          hours: 2,
+          minutes: 3,
+          seconds: 4,
+        },
+        now
+      )
+
+      expect(fnResult.getDate()).toBe(then.getDate())
+      expect(fnResult.getHours()).toBe(then.getHours())
+      expect(fnResult.getMinutes()).toBe(then.getMinutes())
+      expect(fnResult.getSeconds()).toBe(then.getSeconds())
+    })
+
+    it("returns the correct date in the past", () => {
+      const then = new Date(now)
+
+      then.setDate(then.getDate() - 1)
+      then.setHours(then.getHours() - 2)
+      then.setMinutes(then.getMinutes() - 3)
+      then.setSeconds(then.getSeconds() - 4)
+
+      const fnResult = _.getDateFromDuration(
+        {
+          days: -1,
+          hours: -2,
+          minutes: -3,
+          seconds: -4,
+        },
+        now
+      )
+
+      expect(fnResult.getDate()).toBe(then.getDate())
+      expect(fnResult.getHours()).toBe(then.getHours())
+      expect(fnResult.getMinutes()).toBe(then.getMinutes())
+      expect(fnResult.getSeconds()).toBe(then.getSeconds())
+    })
+  })
+
+  describe("ago", () => {
     const now = new Date()
 
     it("returns the correct date in the past", () => {
@@ -93,11 +144,11 @@ describe("time & dates", () => {
       then.setMinutes(then.getMinutes() - 3)
       then.setSeconds(then.getSeconds() - 4)
 
-      const fnResult = _.getDateFromDuration({
-        days: -1,
-        hours: -2,
-        minutes: -3,
-        seconds: -4,
+      const fnResult = _.ago({
+        days: 1,
+        hours: 2,
+        minutes: 3,
+        seconds: 4,
       })
 
       expect(fnResult.getDate()).toBe(then.getDate())
@@ -105,6 +156,10 @@ describe("time & dates", () => {
       expect(fnResult.getMinutes()).toBe(then.getMinutes())
       expect(fnResult.getSeconds()).toBe(then.getSeconds())
     })
+  })
+
+  describe("fromNow", () => {
+    const now = new Date()
 
     it("returns the correct date in the future", () => {
       const then = new Date(now)
@@ -114,7 +169,7 @@ describe("time & dates", () => {
       then.setMinutes(then.getMinutes() + 3)
       then.setSeconds(then.getSeconds() + 4)
 
-      const fnResult = _.getDateFromDuration({
+      const fnResult = _.fromNow({
         days: 1,
         hours: 2,
         minutes: 3,

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -402,6 +402,11 @@ describe("shave", () => {
 })
 
 describe("arrays", () => {
+  describe("multiplyArray", () => {
+    it("multiplies the array N times", () => {
+      expect(_.multiplyArray([1, 2, 3], 3)).toEqual([1, 2, 3, 1, 2, 3, 1, 2, 3])
+    })
+  })
   describe("shuffle", () => {
     it("returns the array in a different order", () => {
       const arr = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -696,6 +696,15 @@ describe("objects", () => {
     })
   })
 
+  describe("into", () => {
+    it("returns the desired new shapre", () => {
+      const obj = { user: { name: "Stephen", age: 39, sex: "M" } }
+      expect(
+        _.into(obj, (key, value) => ({ [value.name]: value.age }))
+      ).toEqual({ Stephen: 39 })
+    })
+  })
+
   describe("sumOfKeyValue", () => {
     it("returns the sum of the key value", () => {
       const arr = [

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -457,7 +457,7 @@ describe("shave", () => {
 })
 
 describe("arrays", () => {
-  describe("multiplyArray", () => {
+  describe("repeatArray", () => {
     it("multiplies the array N times", () => {
       expect(_.repeatArray([1, 2, 3], 3)).toEqual([1, 2, 3, 1, 2, 3, 1, 2, 3])
     })

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -697,7 +697,7 @@ describe("objects", () => {
   })
 
   describe("into", () => {
-    it("returns the desired new shapre", () => {
+    it("returns the desired new shape", () => {
       const obj = { user: { name: "Stephen", age: 39, sex: "M" } }
       expect(
         _.into(obj, (key, value) => ({ [value.name]: value.age }))

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -404,7 +404,7 @@ describe("shave", () => {
 describe("arrays", () => {
   describe("multiplyArray", () => {
     it("multiplies the array N times", () => {
-      expect(_.multiplyArray([1, 2, 3], 3)).toEqual([1, 2, 3, 1, 2, 3, 1, 2, 3])
+      expect(_.repeatArray([1, 2, 3], 3)).toEqual([1, 2, 3, 1, 2, 3, 1, 2, 3])
     })
   })
   describe("shuffle", () => {

--- a/gladney.ts
+++ b/gladney.ts
@@ -627,7 +627,7 @@ export function capitalize(str: string, lowercaseOthers = false) {
 
 /**
  * Returns a boolean of whether not the first string includes the second string, ignoring case.
- * 
+ *
  * Example:
  * ```typescript
  * lazyIncludes("Hello world", "LL") //=> true
@@ -695,6 +695,17 @@ export function shave<T extends string | any[]>(
   return (
     n > 0 ? iterable.slice(0, iterable.length - n) : iterable.slice(n * -1)
   ) as StringOrArray<T>
+}
+
+/** Returns an array with elements copied N times.
+ *
+ * Example:
+ * ```typescript
+ * multiplyArray([1, 2, 3], 3) //=> [1, 2, 3, 1, 2, 3, 1, 2, 3]
+ * ```
+ */
+export function multiplyArray<T>(arr: T[], n: number) {
+  return [].concat(...Array(n).fill(arr))
 }
 
 /** Returns an array with the items randomly ordered.

--- a/gladney.ts
+++ b/gladney.ts
@@ -704,7 +704,7 @@ export function shave<T extends string | any[]>(
  * multiplyArray([1, 2, 3], 3) //=> [1, 2, 3, 1, 2, 3, 1, 2, 3]
  * ```
  */
-export function multiplyArray<T>(arr: T[], n: number) {
+export function multiplyArray<T>(arr: T[], n: number): T[] {
   return [].concat(...Array(n).fill(arr))
 }
 

--- a/gladney.ts
+++ b/gladney.ts
@@ -225,7 +225,7 @@ function getMillisecondsFromDuration(duration: Partial<Duration>) {
   return result
 }
 
-/** Returns a date in the future or past based on a duration from now
+/** Returns a date in the future or past based on a duration from a specific date
  *
  * Example:
  *
@@ -233,10 +233,10 @@ function getMillisecondsFromDuration(duration: Partial<Duration>) {
  * const fromDate = new Date("Jan 1, 2024 12:00:00AM")
  * //=> Date: "2024-01-01T05:00:00.000Z"
  *
- * getDateFromDuration({days: 1: hours: 2, minutes: 3, seconds: 4}, "future", fromDate)
+ * getDateFromDuration({days: 1: hours: 2, minutes: 3, seconds: 4}, fromDate)
  * //=> Date: "2024-01-02T07:03:04.000Z"
  *
- * getDateFromDuration({days: 1: hours: 2, minutes: 3, seconds: 4}, "past", fromDate)
+ * getDateFromDuration({days: -1: hours: -2, minutes: -3, seconds: -4}, fromDate)
  * //=> Date: "2023-12-31T02:56:56.000Z"
  * ```
  */
@@ -245,6 +245,39 @@ export function getDateFromDuration(
   startDate: Date = new Date()
 ) {
   return new Date(startDate.getTime() + getMillisecondsFromDuration(duration))
+}
+
+/** Returns a date in the past based on a duration from now
+ *
+ * Example:
+ *
+ * ```typescript
+ * // Jan 1, 2024 12:00:00AM
+ * ago({days: 1: hours: 2, minutes: 3, seconds: 4})
+ *
+ * //=> Date: "2023-12-31T02:56:56.000Z"
+ * ```
+ */
+export function ago(duration: Partial<Duration>) {
+  const negativeDuration = objectInto(duration, (key, val) => ({
+    [key]: val! * -1,
+  }))
+  return getDateFromDuration(negativeDuration)
+}
+
+/** Returns a date in the future based on a duration from now
+ *
+ * Example:
+ *
+ * ```typescript
+ * // Jan 1, 2024 12:00:00AM
+ * ago({days: 1: hours: 2, minutes: 3, seconds: 4})
+ *
+ * //=> Date: "2024-01-02T07:03:04.000Z"
+ * ```
+ */
+export function fromNow(duration: Partial<Duration>) {
+  return getDateFromDuration(duration)
 }
 
 /** Returns a `Duration` with the number of years, months, weeks, days, hours, minutes and seconds until 

--- a/gladney.ts
+++ b/gladney.ts
@@ -1096,9 +1096,9 @@ export function swapItems<T>(arr: T[], index1: number, index2: number) {
  */
 export function arrayInto<T extends any[]>(
   arr: T,
-  fn: (i: T[number]) => object
+  fn: (item: T[number], index?: number) => object
 ) {
-  return arr.reduce((acc, i) => ({ ...acc, ...fn(i) }), {})
+  return arr.reduce((acc, i, index) => ({ ...acc, ...fn(i, index) }), {})
 }
 
 /** Returns a boolean of whether or not two arrays or two objects have the same items or key value pairs respectively. You can 

--- a/gladney.ts
+++ b/gladney.ts
@@ -1207,7 +1207,7 @@ export function pickKeys<T extends object, U extends keyof T>(
  * //=> { "Stephen": "39/M" }
  * ```
  */
-function into<T extends object>(
+export function into<T extends object>(
   obj: T,
   fn: (key: keyof T, val: T[keyof T]) => object
 ) {

--- a/gladney.ts
+++ b/gladney.ts
@@ -704,7 +704,7 @@ export function shave<T extends string | any[]>(
  * multiplyArray([1, 2, 3], 3) //=> [1, 2, 3, 1, 2, 3, 1, 2, 3]
  * ```
  */
-export function multiplyArray<T>(arr: T[], n: number): T[] {
+export function repeatArray<T>(arr: T[], n: number): T[] {
   return [].concat(...Array(n).fill(arr))
 }
 

--- a/gladney.ts
+++ b/gladney.ts
@@ -1085,6 +1085,22 @@ export function swapItems<T>(arr: T[], index1: number, index2: number) {
   })
 }
 
+/** Tranforms an array into an object with keys and values provided via callback function
+ *
+ * Example:
+ * ```typescript
+ * const arr = [{ first: "John", last: "Doe" }]
+ *
+ * arrayInto(arr, (i) => ({[i.first]: i.last})) //=> { "John": "Doe" }
+ * ```
+ */
+export function arrayInto<T extends any[]>(
+  arr: T,
+  fn: (i: T[number]) => object
+) {
+  return arr.reduce((acc, i) => ({ ...acc, ...fn(i) }), {})
+}
+
 /** Returns a boolean of whether or not two arrays or two objects have the same items or key value pairs respectively. You can 
  optionally pass in a boolean to require that the order of the items matches for arrays (default: false) and a boolean to 
  apply case sensitivity (default: false).
@@ -1231,7 +1247,7 @@ export function pickKeys<T extends object, U extends keyof T>(
  * //=> { "Stephen": "39/M" }
  * ```
  */
-export function into<T extends object, K extends keyof T, V extends T[K]>(
+export function objectInto<T extends object, K extends keyof T, V extends T[K]>(
   obj: T,
   fn: (key: K, val: V) => object
 ) {

--- a/gladney.ts
+++ b/gladney.ts
@@ -626,6 +626,19 @@ export function capitalize(str: string, lowercaseOthers = false) {
 }
 
 /**
+ * Returns a boolean of whether not the first string includes the second string, ignoring case.
+ * 
+ * Example:
+ * ```typescript
+ * lazyIncludes("Hello world", "LL") //=> true
+ * lazyIncludes("Hello world", "ff") //=> false
+ * ```
+ */
+export function lazyIncludes(str1: string, str2: string) {
+  return String(str1).toLowerCase().includes(String(str2).toLowerCase())
+}
+
+/**
  * Returns a string lowercased with non letter/number characters removed and spaces and underscores replaced with a separator (- by default)
  *
  * Example:

--- a/gladney.ts
+++ b/gladney.ts
@@ -1196,6 +1196,26 @@ export function pickKeys<T extends object, U extends keyof T>(
   return result as Pick<T, U>
 }
 
+/** Tranforms an object into a new shape provided via callback function
+ *
+ * Example:
+ * ```typescript
+ * const obj = { user: { id: 1, name: "Stephen", age: 39, sex: "M"} }
+ *
+ * into(obj, (key, value) => ({[value.name]: `${value.age}/${value.sex}`}))
+ *
+ * //=> { "Stephen": "39/M" }
+ * ```
+ */
+function into<T extends object>(
+  obj: T,
+  fn: (key: keyof T, val: T[keyof T]) => object
+) {
+  return Object.keys(obj).reduce((acc, k) => {
+    return { ...acc, ...fn(k as keyof T, obj[k as keyof T]) }
+  }, {})
+}
+
 /** Returns the sum of the values of a specific shared key in an array of objects.
  *
  * Example:

--- a/gladney.ts
+++ b/gladney.ts
@@ -1207,13 +1207,14 @@ export function pickKeys<T extends object, U extends keyof T>(
  * //=> { "Stephen": "39/M" }
  * ```
  */
-export function into<T extends object>(
+export function into<T extends object, K extends keyof T, V extends T[K]>(
   obj: T,
-  fn: (key: keyof T, val: T[keyof T]) => object
+  fn: (key: K, val: V) => object
 ) {
-  return Object.keys(obj).reduce((acc, k) => {
-    return { ...acc, ...fn(k as keyof T, obj[k as keyof T]) }
-  }, {})
+  return Object.keys(obj).reduce(
+    (acc, k) => ({ ...acc, ...fn(k as K, obj[k as K] as V) }),
+    {}
+  )
 }
 
 /** Returns the sum of the values of a specific shared key in an array of objects.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gladknee",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "A zero-dependency utility library written in TypeScript",
   "main": "dist/gladney.js",
   "types": "dist/gladney.d.ts",


### PR DESCRIPTION
## New functions
`objectInto()` - Re-shape an object via a callback function with (key, value) args
`arrayInto()` - Convert an array to an object via callback function with (item, index) args
`lazyIncludes()` - Case-insensitive version of String().includes
`repeatArray()` - Repeat items in an array N times
`ago()` - Fast way to use getDateFromDuration in the past
`fromNow()` - Semantic counterpart to `ago()`