### PR TITLE
1.12.2 Fix round add convert duration

### DIFF
--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -1,4 +1,5 @@
 import * as _ from "./gladney"
+import type { Duration } from "./gladney"
 
 describe("numbers", () => {
   describe("round", () => {
@@ -266,6 +267,18 @@ describe("time & dates", () => {
         minutes: 5,
         seconds: 43,
       })
+    })
+  })
+
+  describe("convertDuration", () => {
+    it("converts Duration correctly", () => {
+      const duration: Duration = { seconds: 30, minutes: 5, hours: 2, days: 3 }
+
+      expect(_.convertDuration(duration, "days", 0.00001)).toEqual(3.08715)
+      expect(_.convertDuration(duration, "hours", 0.00001)).toEqual(74.09167)
+      expect(_.convertDuration(duration, "minutes")).toEqual(4445.5)
+      expect(_.convertDuration(duration, "seconds")).toEqual(266730)
+      expect(_.convertDuration(duration, "milliseconds")).toEqual(266730000)
     })
   })
 

--- a/gladney.ts
+++ b/gladney.ts
@@ -10,7 +10,11 @@ import type { Router } from "express"
 * ```
  **/
 export function round(n: number, precision: number) {
-  return Math.round(n / precision) * precision
+  const multiplier = 1 / precision
+  const rounded = Math.round(n * multiplier) / multiplier
+
+  const precisionDigits = -Math.floor(Math.log10(precision))
+  return Number(rounded.toFixed(clampNumber(precisionDigits, 0, 100)))
 }
 
 /** Returns the sum of given numbers.
@@ -372,6 +376,31 @@ export function isPast(date: Date) {
 export function duration(dateA: Date, dateB: Date) {
   const diff = Math.abs(dateA.getTime() - dateB.getTime())
   return durationFromMilliseconds(diff)
+}
+
+export function convertDuration(
+  d: Duration,
+  to: "milliseconds" | "seconds" | "minutes" | "hours" | "days",
+  precision?: number
+) {
+  const ms = getMillisecondsFromDuration(d)
+  const seconds = ms / 1000
+  const minutes = seconds / 60
+  const hours = minutes / 60
+  const days = hours / 24
+
+  switch (to) {
+    case "milliseconds":
+      return precision ? round(ms, precision) : ms
+    case "seconds":
+      return precision ? round(seconds, precision) : seconds
+    case "minutes":
+      return precision ? round(minutes, precision) : minutes
+    case "hours":
+      return precision ? round(hours, precision) : hours
+    case "days":
+      return precision ? round(days, precision) : days
+  }
 }
 
 /** Returns the relative time difference of two dates
@@ -2462,7 +2491,7 @@ function withMatchOptions(
 }
 // TYPES
 
-export interface Duration {
+export type Duration = {
   days: number
   hours: number
   minutes: number

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gladknee",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "A zero-dependency utility library written in TypeScript",
   "main": "dist/gladney.js",
   "types": "dist/gladney.d.ts",


### PR DESCRIPTION
- Fixes a bug where round doesn't always return the correct precision
- Adds `convertDuration` function to convert a Duration to various units of time