### PR TITLE
1.13.1 - Rename duration and createDuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ To add to your project, just run `npm install gladknee`
 To use any functions from the library, simply import the specific function(s) you wish to use where needed.
 
 ```typescript
-import { lowerCaseNoSpaces } from "gladknee"
+import { memoize } from "gladknee"
 
-lowerCaseNoSpaces("Hello World!") //=> "helloworld"
+const memoizedFunction = memoize(someFunction)
 ```
 
 ### Documentation

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -356,6 +356,23 @@ describe("time & dates", () => {
     })
   })
 
+  describe("createDuration", () => {
+    it("does not require all time units", () => {
+      expect(
+        _.omitKeys(
+          _.createDuration({ hours: 1 }),
+          "isGreaterThan",
+          "isLessThan"
+        )
+      ).toEqual({
+        seconds: 0,
+        minutes: 0,
+        hours: 1,
+        days: 0,
+      })
+    })
+  })
+
   describe("relativeTimeDiff", () => {
     it("returns the correct relative duration", () => {
       const secondsInAMinute = 60

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -262,7 +262,11 @@ describe("time & dates", () => {
       end.setSeconds(end.getSeconds() - 43)
 
       expect(
-        _.omitKeys(_.duration(start, end), "isGreaterThan", "isLessThan")
+        _.omitKeys(
+          _.durationFromDates(start, end),
+          "isGreaterThan",
+          "isLessThan"
+        )
       ).toEqual({
         days: 11,
         hours: 2,
@@ -274,7 +278,12 @@ describe("time & dates", () => {
 
   describe("convertDuration", () => {
     it("converts Duration correctly", () => {
-      const duration: Duration = { seconds: 30, minutes: 5, hours: 2, days: 3 }
+      const duration: Duration = _.duration({
+        seconds: 30,
+        minutes: 5,
+        hours: 2,
+        days: 3,
+      })
 
       expect(_.convertDuration(duration, "days", 0.00001)).toEqual(3.08715)
       expect(_.convertDuration(duration, "hours", 0.00001)).toEqual(74.09167)
@@ -286,13 +295,13 @@ describe("time & dates", () => {
 
   describe("Duration.isGreaterThan", () => {
     it("returns true if the duration is greater than the other", () => {
-      const largerDuration = _.createDuration({
+      const largerDuration = _.duration({
         days: 1,
         hours: 0,
         minutes: 0,
         seconds: 0,
       })
-      const smallerDuration = _.createDuration({
+      const smallerDuration = _.duration({
         days: 0,
         hours: 23,
         minutes: 10,
@@ -303,13 +312,13 @@ describe("time & dates", () => {
     })
 
     it("returns false if the duration is not greater than the other", () => {
-      const largerDuration = _.createDuration({
+      const largerDuration = _.duration({
         days: 1,
         hours: 0,
         minutes: 0,
         seconds: 0,
       })
-      const smallerDuration = _.createDuration({
+      const smallerDuration = _.duration({
         days: 0,
         hours: 23,
         minutes: 10,
@@ -322,13 +331,13 @@ describe("time & dates", () => {
 
   describe("Duration.isLessThan", () => {
     it("returns true if the duration is less than the other", () => {
-      const largerDuration = _.createDuration({
+      const largerDuration = _.duration({
         days: 1,
         hours: 0,
         minutes: 0,
         seconds: 0,
       })
-      const smallerDuration = _.createDuration({
+      const smallerDuration = _.duration({
         days: 0,
         hours: 23,
         minutes: 10,
@@ -339,13 +348,13 @@ describe("time & dates", () => {
     })
 
     it("returns false if the duration is not less than the other", () => {
-      const largerDuration = _.createDuration({
+      const largerDuration = _.duration({
         days: 1,
         hours: 0,
         minutes: 0,
         seconds: 0,
       })
-      const smallerDuration = _.createDuration({
+      const smallerDuration = _.duration({
         days: 0,
         hours: 23,
         minutes: 10,
@@ -356,14 +365,10 @@ describe("time & dates", () => {
     })
   })
 
-  describe("createDuration", () => {
+  describe("duration", () => {
     it("does not require all time units", () => {
       expect(
-        _.omitKeys(
-          _.createDuration({ hours: 1 }),
-          "isGreaterThan",
-          "isLessThan"
-        )
+        _.omitKeys(_.duration({ hours: 1 }), "isGreaterThan", "isLessThan")
       ).toEqual({
         seconds: 0,
         minutes: 0,

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -261,7 +261,9 @@ describe("time & dates", () => {
       end.setMinutes(end.getMinutes() - 5)
       end.setSeconds(end.getSeconds() - 43)
 
-      expect(_.duration(start, end)).toEqual({
+      expect(
+        _.omitKeys(_.duration(start, end), "isGreaterThan", "isLessThan")
+      ).toEqual({
         days: 11,
         hours: 2,
         minutes: 5,
@@ -279,6 +281,78 @@ describe("time & dates", () => {
       expect(_.convertDuration(duration, "minutes")).toEqual(4445.5)
       expect(_.convertDuration(duration, "seconds")).toEqual(266730)
       expect(_.convertDuration(duration, "milliseconds")).toEqual(266730000)
+    })
+  })
+
+  describe("Duration.isGreaterThan", () => {
+    it("returns true if the duration is greater than the other", () => {
+      const largerDuration = _.createDuration({
+        days: 1,
+        hours: 0,
+        minutes: 0,
+        seconds: 0,
+      })
+      const smallerDuration = _.createDuration({
+        days: 0,
+        hours: 23,
+        minutes: 10,
+        seconds: 20,
+      })
+
+      expect(largerDuration.isGreaterThan(smallerDuration)).toBe(true)
+    })
+
+    it("returns false if the duration is not greater than the other", () => {
+      const largerDuration = _.createDuration({
+        days: 1,
+        hours: 0,
+        minutes: 0,
+        seconds: 0,
+      })
+      const smallerDuration = _.createDuration({
+        days: 0,
+        hours: 23,
+        minutes: 10,
+        seconds: 20,
+      })
+
+      expect(smallerDuration.isGreaterThan(largerDuration)).toBe(false)
+    })
+  })
+
+  describe("Duration.isLessThan", () => {
+    it("returns true if the duration is less than the other", () => {
+      const largerDuration = _.createDuration({
+        days: 1,
+        hours: 0,
+        minutes: 0,
+        seconds: 0,
+      })
+      const smallerDuration = _.createDuration({
+        days: 0,
+        hours: 23,
+        minutes: 10,
+        seconds: 20,
+      })
+
+      expect(smallerDuration.isLessThan(largerDuration)).toBe(true)
+    })
+
+    it("returns false if the duration is not less than the other", () => {
+      const largerDuration = _.createDuration({
+        days: 1,
+        hours: 0,
+        minutes: 0,
+        seconds: 0,
+      })
+      const smallerDuration = _.createDuration({
+        days: 0,
+        hours: 23,
+        minutes: 10,
+        seconds: 20,
+      })
+
+      expect(largerDuration.isLessThan(smallerDuration)).toBe(false)
     })
   })
 

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -1,4 +1,5 @@
 import * as _ from "./gladney"
+import type { Duration } from "./gladney"
 
 describe("numbers", () => {
   describe("round", () => {
@@ -266,6 +267,18 @@ describe("time & dates", () => {
         minutes: 5,
         seconds: 43,
       })
+    })
+  })
+
+  describe("convertDuration", () => {
+    it("converts Duration correctly", () => {
+      const duration: Duration = { seconds: 30, minutes: 5, hours: 2, days: 3 }
+
+      expect(_.convertDuration(duration, "days", 0.00001)).toEqual(3.08715)
+      expect(_.convertDuration(duration, "hours", 0.00001)).toEqual(74.09167)
+      expect(_.convertDuration(duration, "minutes")).toEqual(4445.5)
+      expect(_.convertDuration(duration, "seconds")).toEqual(266730)
+      expect(_.convertDuration(duration, "milliseconds")).toEqual(266730000)
     })
   })
 

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -1280,6 +1280,38 @@ describe("misc", () => {
     })
   })
 
+  describe("caseEquals", () => {
+    it("returns a corresponding expression if a match is found", () => {
+      const widthByHeight = _.round(1920 / 1080, 0.01)
+
+      const ratio = _.caseEquals(
+        widthByHeight,
+        [1.78, "16:9"],
+        [1.5, "3:2"],
+        [1.33, "4:3"],
+        [1, "1:1"],
+        "Uncommon aspect ratio"
+      )
+
+      expect(ratio).toBe("16:9")
+    })
+
+    it("returns the default express if no match is found", () => {
+      const widthByHeight = _.round(2200 / 1080, 0.01)
+
+      const ratio = _.caseEquals(
+        widthByHeight,
+        [1.78, "16:9"],
+        [1.5, "3:2"],
+        [1.33, "4:3"],
+        [1, "1:1"],
+        "Uncommon aspect ratio"
+      )
+
+      expect(ratio).toBe("Uncommon aspect ratio")
+    })
+  })
+
   describe("objectToQueryParams", () => {
     it("converts an object to string of query params", () => {
       const obj = { name: "john", age: 30 }

--- a/gladney.ts
+++ b/gladney.ts
@@ -2426,6 +2426,39 @@ export function stripHTML(text: string) {
   return result
 }
 
+/**
+ * Returns a corresponding expression based on a matching value of an expression provided. Uses
+ * `isEqual` under the hood.
+ *
+ * Example:
+ * ```typescript
+ * const widthByHeight = round(1920 / 1080, 0.01)
+ *
+ * const ratio = caseEquals(
+ *   widthByHeight,
+ *   [1.78, "16:9"],
+ *   [1.5, "3:2"],
+ *   [1.33, "4:3"],
+ *   [1, "1:1"],
+ *   "Uncommon aspect ratio"
+ * )
+//=> 16:9
+ * ```
+ */
+
+export function caseEquals<T = any, U = any>(
+  value: T,
+  ...casesAndDefault: [...c: [T, U][], U]
+) {
+  for (let i = 0; i < casesAndDefault.length; i++) {
+    const currentCase = casesAndDefault[i]
+    if (Array.isArray(currentCase) && value === currentCase[0]) {
+      return currentCase[1]
+    }
+  }
+  return casesAndDefault[casesAndDefault.length - 1]
+}
+
 const defaultMatchOptions: MatchOptions = {
   ignoreCase: false,
   ignoreSpace: false,

--- a/gladney.ts
+++ b/gladney.ts
@@ -2434,7 +2434,7 @@ export function stripHTML(text: string) {
  * ```typescript
  * const widthByHeight = round(1920 / 1080, 0.01) // 1.78
  *
- * const ratio = caseEquals(
+ * const apectRatio = caseEquals(
  *   widthByHeight,
  *   [1.78, "16:9"],
  *   [1.5, "3:2"],

--- a/gladney.ts
+++ b/gladney.ts
@@ -2432,7 +2432,7 @@ export function stripHTML(text: string) {
  *
  * Example:
  * ```typescript
- * const widthByHeight = round(1920 / 1080, 0.01)
+ * const widthByHeight = round(1920 / 1080, 0.01) // 1.78
  *
  * const ratio = caseEquals(
  *   widthByHeight,

--- a/gladney.ts
+++ b/gladney.ts
@@ -2442,7 +2442,7 @@ export function stripHTML(text: string) {
  *   [1, "1:1"],
  *   "Uncommon aspect ratio"
  * )
-//=> 16:9
+ * //=> "16:9"
  * ```
  */
 

--- a/gladney.ts
+++ b/gladney.ts
@@ -2443,6 +2443,7 @@ export function stripHTML(text: string) {
  *   "Uncommon aspect ratio"
  * )
  * //=> "16:9"
+ */
 
 export function caseEquals<T = any, U = any>(
   value: T,

--- a/gladney.ts
+++ b/gladney.ts
@@ -10,7 +10,11 @@ import type { Router } from "express"
 * ```
  **/
 export function round(n: number, precision: number) {
-  return Math.round(n / precision) * precision
+  const multiplier = 1 / precision
+  const rounded = Math.round(n * multiplier) / multiplier
+
+  const precisionDigits = -Math.floor(Math.log10(precision))
+  return Number(rounded.toFixed(clampNumber(precisionDigits, 0, 100)))
 }
 
 /** Returns the sum of given numbers.
@@ -372,6 +376,31 @@ export function isPast(date: Date) {
 export function duration(dateA: Date, dateB: Date) {
   const diff = Math.abs(dateA.getTime() - dateB.getTime())
   return durationFromMilliseconds(diff)
+}
+
+export function convertDuration(
+  d: Duration,
+  to: "milliseconds" | "seconds" | "minutes" | "hours" | "days",
+  precision?: number
+) {
+  const ms = getMillisecondsFromDuration(d)
+  const seconds = ms / 1000
+  const minutes = seconds / 60
+  const hours = minutes / 60
+  const days = hours / 24
+
+  switch (to) {
+    case "milliseconds":
+      return precision ? round(ms, precision) : ms
+    case "seconds":
+      return precision ? round(seconds, precision) : seconds
+    case "minutes":
+      return precision ? round(minutes, precision) : minutes
+    case "hours":
+      return precision ? round(hours, precision) : hours
+    case "days":
+      return precision ? round(days, precision) : days
+  }
 }
 
 /** Returns the relative time difference of two dates
@@ -2462,7 +2491,7 @@ function withMatchOptions(
 }
 // TYPES
 
-export interface Duration {
+export type Duration = {
   days: number
   hours: number
   minutes: number

--- a/gladney.ts
+++ b/gladney.ts
@@ -202,7 +202,7 @@ const secondsInADay = 86400
 function durationFromMilliseconds(milliseconds: number): Duration {
   const seconds = Math.floor(milliseconds / 1000)
 
-  return createDuration({
+  return duration({
     days: Math.floor(seconds / secondsInADay),
     hours: Math.floor((seconds % secondsInADay) / secondsInAnHour),
     minutes: Math.floor((seconds % secondsInAnHour) / secondsInAMinute),
@@ -300,7 +300,7 @@ interface Duration {
  **/
 
 export function timeUntil(date: Date): Duration {
-  return duration(new Date(), new Date(date))
+  return durationFromDates(new Date(), new Date(date))
 }
 
 /** Returns a `Duration` with the number of years, months, weeks, days, hours, minutes and seconds since a
@@ -315,7 +315,7 @@ interface Duration {
  * ```
  **/
 export function timeSince(date: Date): Duration {
-  return duration(new Date(), new Date(date))
+  return durationFromDates(new Date(), new Date(date))
 }
 
 /** Returns the corresponding human readable day name of an integer (0-6).
@@ -376,7 +376,7 @@ export function isPast(date: Date) {
  *  }
  * ```
  */
-export function duration(dateA: Date | string, dateB: Date | string) {
+export function durationFromDates(dateA: Date | string, dateB: Date | string) {
   const dateASerialized = typeof dateA === "string" ? new Date(dateA) : dateA
   const dateBSerialized = typeof dateB === "string" ? new Date(dateB) : dateB
 
@@ -384,7 +384,7 @@ export function duration(dateA: Date | string, dateB: Date | string) {
   return durationFromMilliseconds(diff)
 }
 
-export function createDuration({
+export function duration({
   seconds,
   minutes,
   hours,
@@ -395,12 +395,15 @@ export function createDuration({
   hours?: number
   days?: number
 }) {
-  const resultingDuration = {
+  const resultingDuration: Duration = {
     seconds: seconds ?? 0,
     minutes: minutes ?? 0,
     hours: hours ?? 0,
     days: days ?? 0,
+    isGreaterThan: (d: Duration) => false,
+    isLessThan: (d: Duration) => false,
   }
+
   return {
     ...resultingDuration,
     isGreaterThan: (otherDuration: Duration) =>
@@ -409,7 +412,7 @@ export function createDuration({
     isLessThan: (otherDuration: Duration) =>
       convertDuration(resultingDuration, "seconds") <
       convertDuration(otherDuration, "seconds"),
-  }
+  } as Duration
 }
 
 export function convertDuration(
@@ -2562,8 +2565,8 @@ export type Duration = {
   hours: number
   minutes: number
   seconds: number
-  isGreaterThan?: (otherDuration: Duration) => boolean
-  isLessThan?: (otherDuration: Duration) => boolean
+  isGreaterThan: (otherDuration: Duration) => boolean
+  isLessThan: (otherDuration: Duration) => boolean
 }
 
 type DayName =

--- a/gladney.ts
+++ b/gladney.ts
@@ -390,16 +390,16 @@ export function createDuration({
   hours,
   days,
 }: {
-  seconds: number
-  minutes: number
-  hours: number
-  days: number
+  seconds?: number
+  minutes?: number
+  hours?: number
+  days?: number
 }) {
   const resultingDuration = {
-    seconds,
-    minutes,
-    hours,
-    days,
+    seconds: seconds ?? 0,
+    minutes: minutes ?? 0,
+    hours: hours ?? 0,
+    days: days ?? 0,
   }
   return {
     ...resultingDuration,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gladknee",
-  "version": "1.8.3",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gladknee",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "A zero-dependency utility library written in TypeScript",
   "main": "dist/gladney.js",
   "types": "dist/gladney.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gladknee",
-  "version": "1.12.6",
+  "version": "1.12.7",
   "description": "A zero-dependency utility library written in TypeScript",
   "main": "dist/gladney.js",
   "types": "dist/gladney.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gladknee",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "description": "A zero-dependency utility library written in TypeScript",
   "main": "dist/gladney.js",
   "types": "dist/gladney.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gladknee",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "description": "A zero-dependency utility library written in TypeScript",
   "main": "dist/gladney.js",
   "types": "dist/gladney.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gladknee",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "description": "A zero-dependency utility library written in TypeScript",
   "main": "dist/gladney.js",
   "types": "dist/gladney.d.ts",


### PR DESCRIPTION
`duration()` becomes `durationFromDates`
`createDuration()` becomes `duration()`