### PR TITLE
New funcs oct 29

### DIFF
--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -979,6 +979,14 @@ describe("arrays", () => {
         "1000",
       ])
     })
+
+    describe("steps", () => {
+      it("returns the diff between each item", () => {
+        expect(_.steps([1, 2, 3, 4])).toEqual([1, 1, 1])
+        expect(_.steps([2, 4, 7, 11])).toEqual([2, 3, 4])
+        expect(_.steps([10, 8, 9, 2])).toEqual([-2, 1, -7])
+      })
+    })
   })
 
   describe("reject", () => {
@@ -1602,6 +1610,20 @@ describe("misc", () => {
       throttledFunc()
       await _.pause(300)
       expect(func).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe("retry", () => {
+    it("retries the function the specified number of times", async () => {
+      const countFn = jest.fn()
+      const rejectFunction = () =>
+        new Promise((resolve, reject) => {
+          countFn()
+          reject()
+        })
+
+      await _.retry(rejectFunction, 3, 1)
+      expect(countFn).toHaveBeenCalledTimes(3)
     })
   })
 

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -1674,6 +1674,37 @@ describe("misc", () => {
       await _.retry(rejectFunction, 2, 1, failureFn)
       expect(failureFn).not.toHaveBeenCalled()
     })
+
+    it("returns the returned value of the function if successful", async () => {
+      let count = 0
+      const countFn = jest.fn()
+      const failureFn = jest.fn()
+      const rejectFunction = () =>
+        new Promise((resolve, reject) => {
+          countFn()
+          if (count === 1) resolve("hello")
+          else {
+            count++
+            reject()
+          }
+        })
+
+      const returnedValue = await _.retry(rejectFunction, 2, 1, failureFn)
+      expect(returnedValue).toBe("hello")
+    })
+
+    it("returns the returned value of the onFailure function if unsuccessful", async () => {
+      const countFn = jest.fn()
+      const failureFn = () => "hey there"
+      const rejectFunction = () =>
+        new Promise((_, reject) => {
+          countFn()
+          reject()
+        })
+
+      const returnedValue = await _.retry(rejectFunction, 1, 1, failureFn)
+      expect(returnedValue).toBe("hey there")
+    })
   })
 
   describe("rgbToHex", () => {

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -974,6 +974,15 @@ describe("arrays", () => {
       ])
     })
   })
+
+  describe("reject", () => {
+    it("returns items with falsy result", () => {
+      const arr = [1, 2, 3, 4, 5, 6]
+      const isEven = (n: number) => n % 2 === 0
+
+      expect(_.reject(arr, isEven)).toEqual([1, 3, 5])
+    })
+  })
 })
 
 describe("swapItems", () => {
@@ -1612,6 +1621,18 @@ describe("misc", () => {
       expect(_.stripHTML("<html><p>Hello <b>world</b>!</p></html>")).toBe(
         "Hello world!"
       )
+    })
+  })
+
+  describe("limit", () => {
+    it("does not allow the function to be run more times than the limit", () => {
+      const fn = jest.fn()
+      const limitedFn = _.limit(fn, 2)
+      for (let i = 1; i <= 3; i++) {
+        limitedFn()
+      }
+
+      expect(fn).toBeCalledTimes(2)
     })
   })
 })

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -1011,6 +1011,18 @@ describe("arrays", () => {
       ])
     })
   })
+
+  describe("join", () => {
+    it("joins the items with the appropriate separators", () => {
+      expect(_.join(["apples", "oranges"], " and ")).toBe("apples and oranges")
+      expect(_.join(["apples", "oranges"], ", ", " and ")).toBe(
+        "apples and oranges"
+      )
+      expect(_.join(["apples", "oranges", "bananas"], ", ", " and ")).toBe(
+        "apples, oranges and bananas"
+      )
+    })
+  })
 })
 
 describe("swapItems", () => {

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -437,6 +437,24 @@ describe("strings", () => {
     })
   })
 
+  describe("endsWith", () => {
+    it("returns true if word ends with only suffix provided", () => {
+      expect(_.endsWith("hello world", "rld")).toBe(true)
+    })
+
+    it("returns false if word does not end with only suffix provided", () => {
+      expect(_.endsWith("hello world", "sdf")).toBe(false)
+    })
+
+    it("returns true if word ends with at least one of many suffixes provided", () => {
+      expect(_.endsWith("hello world", ["sdf", "rld"])).toBe(true)
+    })
+
+    it("returns false if word does not end with only suffix provided", () => {
+      expect(_.endsWith("hello world", ["sdf", "dsc"])).toBe(false)
+    })
+  })
+
   describe("lazyIncludes", () => {
     it("returns true if the characters are present", () => {
       expect(_.lazyIncludes("Hello world", "LL")).toBeTruthy()

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -583,6 +583,10 @@ describe("shave", () => {
   it("removes elements from the beginning if n is negative", () => {
     expect(_.shave([1, 2, 3, 4], -2)).toEqual([3, 4])
   })
+
+  describe("numbers", () => {
+    expect(_.numbers("1-22-333")).toBe("122333")
+  })
 })
 
 describe("arrays", () => {
@@ -1704,6 +1708,20 @@ describe("misc", () => {
 
       const returnedValue = await _.retry(rejectFunction, 1, 1, failureFn)
       expect(returnedValue).toBe("hey there")
+    })
+  })
+
+  describe("times", () => {
+    it("runs the function the specified number of times", async () => {
+      const fn = jest.fn()
+      await _.times(fn, 3)
+      expect(fn).toBeCalledTimes(3)
+    })
+
+    it("returns the returned value of the last execution", async () => {
+      const fn = () => "hello"
+      const result = await _.times(fn, 3)
+      expect(result).toBe("hello")
     })
   })
 

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -708,20 +708,20 @@ describe("arrays", () => {
     })
   })
 
-  describe("removeDuplicates", () => {
+  describe("unique", () => {
     it("returns the array with duplicates removed", () => {
       const arr = [1, 1, 2, 3, 4, 4, 5]
-      expect(_.removeDuplicates(arr)).toEqual([1, 2, 3, 4, 5])
+      expect(_.unique(arr)).toEqual([1, 2, 3, 4, 5])
     })
 
     it("returns the array with duplicate objects removed", () => {
       const obj = { a: 1, b: 2, c: 3 }
       const arr = [obj, obj, obj]
-      expect(_.removeDuplicates(arr)).toEqual([{ a: 1, b: 2, c: 3 }])
+      expect(_.unique(arr)).toEqual([{ a: 1, b: 2, c: 3 }])
     })
   })
 
-  describe("removeDuplicatesBy", () => {
+  describe("uniqueBy", () => {
     it("removes duplicates by callback result", () => {
       const arr = [
         { a: 1, b: 1 },
@@ -729,7 +729,7 @@ describe("arrays", () => {
         { a: 3, b: 1 },
         { a: 3, b: 3 },
       ]
-      expect(_.removeDuplicatesBy(arr, (i) => i.b)).toEqual([
+      expect(_.uniqueBy(arr, (i) => i.b)).toEqual([
         { a: 1, b: 1 },
         { a: 2, b: 2 },
         { a: 3, b: 3 },
@@ -1227,7 +1227,7 @@ describe("objects", () => {
     })
   })
 
-  describe("removeDuplicatesByKeyValue", () => {
+  describe("uniqueByKeyValue", () => {
     it("removes any subsequent objects with the same key value", () => {
       const members = [
         { id: 1, name: "Stephen" },
@@ -1236,7 +1236,7 @@ describe("objects", () => {
         { id: 4, name: "Dylan" },
       ]
 
-      expect(_.removeDuplicatesByKeyValue(members, "id")).toEqual([
+      expect(_.uniqueByKeyValue(members, "id")).toEqual([
         { id: 1, name: "Stephen" },
         { id: 2, name: "Andrea" },
         { id: 4, name: "Dylan" },

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -455,6 +455,24 @@ describe("strings", () => {
     })
   })
 
+  describe("startsWith", () => {
+    it("returns true if word starts with only prefix provided", () => {
+      expect(_.startsWith("hello world", "hel")).toBe(true)
+    })
+
+    it("returns false if word does not start with only prefix provided", () => {
+      expect(_.startsWith("hello world", "sdf")).toBe(false)
+    })
+
+    it("returns true if word starts with at least one of many prefixes provided", () => {
+      expect(_.startsWith("hello world", ["sdf", "hel"])).toBe(true)
+    })
+
+    it("returns false if word does not start with only prefix provided", () => {
+      expect(_.startsWith("hello world", ["sdf", "dsc"])).toBe(false)
+    })
+  })
+
   describe("lazyIncludes", () => {
     it("returns true if the characters are present", () => {
       expect(_.lazyIncludes("Hello world", "LL")).toBeTruthy()
@@ -1063,6 +1081,25 @@ describe("objects", () => {
     it("returns the object with only the keys provided", () => {
       const obj = { a: 1, b: 2, c: 3 }
       expect(_.pickKeys(obj, "b", "c")).toEqual({ b: 2, c: 3 })
+    })
+  })
+
+  describe("putNew", () => {
+    it("returns an object with the existing key value if it already exists", () => {
+      const obj = { name: "Stephen", age: 39 }
+      expect(_.putNew(obj, "name", "James")).toEqual({
+        name: "Stephen",
+        age: 39,
+      })
+    })
+
+    it("returns an object with a new key value if it doesn't exist", () => {
+      const obj = { name: "Stephen", age: 39 }
+      expect(_.putNew(obj, "city", "Atlanta")).toEqual({
+        name: "Stephen",
+        age: 39,
+        city: "Atlanta",
+      })
     })
   })
 

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -585,7 +585,9 @@ describe("shave", () => {
   })
 
   describe("numbers", () => {
-    expect(_.numbers("1-22-333")).toBe("122333")
+    it("removes non numbers", () => {
+      expect(_.onlyNumbers("1-22-333")).toBe("122333")
+    })
   })
 })
 
@@ -999,6 +1001,14 @@ describe("arrays", () => {
       const isEven = (n: number) => n % 2 === 0
 
       expect(_.reject(arr, isEven)).toEqual([1, 3, 5])
+    })
+  })
+
+  describe("combine", () => {
+    it("combines arrays", () => {
+      expect(_.combine([1, 2, 3], [4, 5], [6, 7, 8])).toEqual([
+        1, 2, 3, 4, 5, 6, 7, 8,
+      ])
     })
   })
 })

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -1059,13 +1059,21 @@ describe("arrays", () => {
       )
     })
   })
-})
 
-describe("swapItems", () => {
-  it("swaps the items at the indexes provided", () => {
-    const arr = [0, 1, 2, 3, 4]
-    expect(_.swapItems(arr, 2, 4)).toEqual([0, 1, 4, 3, 2])
-    expect(_.swapItems(arr, 0, 3)).toEqual([3, 1, 2, 0, 4])
+  describe("swapItems", () => {
+    it("swaps the items at the indexes provided", () => {
+      const arr = [0, 1, 2, 3, 4]
+      expect(_.swapItems(arr, 2, 4)).toEqual([0, 1, 4, 3, 2])
+      expect(_.swapItems(arr, 0, 3)).toEqual([3, 1, 2, 0, 4])
+    })
+  })
+
+  describe("findValue", () => {
+    it("returns the value of the callback fn", () => {
+      const callback = (n: number) => (n > 2 ? n * n : null)
+
+      expect(_.findValue([1, 2, 3, 4], callback)).toBe(9)
+    })
   })
 })
 

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -54,6 +54,12 @@ describe("numbers", () => {
       expect(_.ordinal(13)).toBe("13th")
     })
   })
+
+  describe("digits", () => {
+    it("returns the digits as an array of numbers", () => {
+      expect(_.digits(789234)).toEqual([7, 8, 9, 2, 3, 4])
+    })
+  })
 })
 
 describe("time & dates", () => {

--- a/gladney.ts
+++ b/gladney.ts
@@ -187,6 +187,13 @@ export function mode(...numbers: (number | number[])[]) {
   } else return Number(mostCommon)
 }
 
+export function digits(n: number) {
+  return n
+    .toString()
+    .split("")
+    .map((s) => Number(s))
+}
+
 const secondsInAMinute = 60
 const secondsInAnHour = 3600
 const secondsInADay = 86400

--- a/gladney.ts
+++ b/gladney.ts
@@ -1365,6 +1365,10 @@ export function reject<T>(arr: T[], fn: Func | AsyncFunc) {
   return arr.filter((x) => !fn(x))
 }
 
+export function steps(arr: number[]) {
+  return arr.slice(1).map((item, i) => item - arr[i])
+}
+
 /** Tranforms an array into an object with keys and values provided via callback function
  *
  * Example:
@@ -2178,9 +2182,9 @@ export async function retry<T extends Func | AsyncFunc>(
   attempts: number,
   delay: number
 ) {
-  for (let i = 0; i <= attempts; i++) {
+  for (let i = 1; i <= attempts; i++) {
     try {
-      func()
+      await func()
       break
     } catch {
       await pause(delay)

--- a/gladney.ts
+++ b/gladney.ts
@@ -754,12 +754,37 @@ export function capitalize(str: string, lowercaseOthers = false) {
 }
 
 /**
- * Returns a boolean of whether not the first parameter (array or string) includes the second parameter, ignoring case.
+ * Returns a boolean of whether or not the first string starts with a specific prefix or one of several prefixes
  *
  * Example:
  * ```typescript
- * lazyIncludes("Hello world", "LL") //=> true
- * lazyIncludes("Hello world", "ff") //=> false
+ * startsWith("hello world", "hel") //=> true
+ *
+ * startsWith("hello world", ["sdf", "hel"]) //=> true
+ * ```
+ */
+
+export function startsWith(str: string, suffix: string | string[]): boolean {
+  if (Array.isArray(suffix)) {
+    for (let i = 0; i < suffix.length; i++) {
+      if (str.substring(0, suffix[i].length) === suffix[i]) {
+        return true
+      }
+    }
+    return false
+  } else {
+    return str.substring(0, suffix.length) === suffix
+  }
+}
+
+/**
+ * Returns a boolean of whether or not the first string ends with a specific suffix or one of several suffixes
+ *
+ * Example:
+ * ```typescript
+ * endsWith("hello world", "rld") //=> true
+ *
+ * endsWith("hello world", ["sdf", "rld"]) //=> true
  * ```
  */
 
@@ -775,6 +800,17 @@ export function endsWith(str: string, suffix: string | string[]): boolean {
     return str.substring(str.length - suffix.length) === suffix
   }
 }
+
+/**
+ * Returns a boolean of whether not the first parameter (array or string) includes the second parameter, ignoring case.
+ *
+ * Example:
+ * ```typescript
+ * lazyIncludes("Hello world", "LL") //=> true
+ *
+ * lazyIncludes("Hello world", "ff") //=> false
+ * ```
+ */
 
 export function lazyIncludes<T extends string | any[]>(
   a: T,
@@ -1494,6 +1530,33 @@ export function pickKeys<T extends object, U extends keyof T>(
     }
   })
   return result as Pick<T, U>
+}
+
+/**
+ * Returns an object with a new key value pair added if the key does not already exist
+ *
+ * Example:
+ *
+ * ```typescript
+ * const obj = { name: "Stephen", age: 39 }
+ *
+ * putNew(obj, "name", "James") //=> { name: "Stephen", age: 39}
+ *
+ * putNew(obj, "city", "Atlanta") //=> { name: "Stephen", age: 39, city: "Atlanta" }
+ *
+ * ```
+ */
+export function putNew<T extends Record<string | number, any>>(
+  obj: T,
+  key: string,
+  value: unknown
+) {
+  if (Object.keys(obj).includes(key)) return deepCopy(obj)
+  else {
+    const newObject: Record<string | number, any> = deepCopy(obj)
+    newObject[key] = value
+    return newObject
+  }
 }
 
 /** Tranforms an object into a new shape provided via callback function

--- a/gladney.ts
+++ b/gladney.ts
@@ -509,7 +509,11 @@ export function lowerCaseNoSpaces(str: string) {
  * ```
  */
 export function s(n: number) {
-  return n > 1 || n == 0 ? "s" : ""
+  return n === 1 ? "" : "s"
+}
+
+export function numbers(str: string) {
+  return String(str).replace(/[^0-9]/g, "")
 }
 
 /** Returns a string limited to a max length with "..." or custom filler. You can also choose between a leading, trailing,
@@ -2185,8 +2189,8 @@ export function limit<T extends Func | AsyncFunc>(func: T, limit: number) {
   }
 }
 
-/** Attempts to run a function up to a specified number of times and returns the result if successful. Also accepts a
- * delay in ms between each attempt and optional fallback function if all calls are unsuccessful.
+/** Attempts to run a function up to a specified number of times and returns the result if successful. Also accepts an
+ * optional delay in ms between each attempt and fallback function if all calls are unsuccessful.
  *
  */
 export async function retry<T extends Func | AsyncFunc>(
@@ -2274,6 +2278,23 @@ export function curry<T extends (...args: any[]) => any>(
       : func(...args)
   }
   return curried(func, func.length, []) as CurryFunction<T>
+}
+
+/** Runs a function a specified number of times. Optionally pass in a delay between each execution.
+ * Returns the returned value of the last execution.
+ *
+ */
+export async function times(
+  fn: Func | AsyncFunc,
+  times: number,
+  delay?: number
+) {
+  let result
+  for (let i = 1; i <= times; i++) {
+    result = await fn()
+    if (delay) await pause(delay)
+  }
+  return result
 }
 
 /** Prompts a user in their browser to save some specific text to a file on their machine.
@@ -2636,6 +2657,7 @@ function withMatchOptions(
     return compare
   } else return param
 }
+
 // TYPES
 
 export type Duration = {

--- a/gladney.ts
+++ b/gladney.ts
@@ -763,6 +763,19 @@ export function capitalize(str: string, lowercaseOthers = false) {
  * ```
  */
 
+export function endsWith(str: string, suffix: string | string[]): boolean {
+  if (Array.isArray(suffix)) {
+    for (let i = 0; i < suffix.length; i++) {
+      if (str.substring(str.length - suffix[i].length) === suffix[i]) {
+        return true
+      }
+    }
+    return false
+  } else {
+    return str.substring(str.length - suffix.length) === suffix
+  }
+}
+
 export function lazyIncludes<T extends string | any[]>(
   a: T,
   b: T extends (infer U)[] ? U : string

--- a/gladney.ts
+++ b/gladney.ts
@@ -2173,6 +2173,21 @@ export function limit<T extends Func | AsyncFunc>(func: T, limit: number) {
   }
 }
 
+export async function retry<T extends Func | AsyncFunc>(
+  func: T,
+  attempts: number,
+  delay: number
+) {
+  for (let i = 0; i <= attempts; i++) {
+    try {
+      func()
+      break
+    } catch {
+      await pause(delay)
+    }
+  }
+}
+
 /** Returns a memoized version of a function.
  *
  * _Memoization is the process of caching a function's result so that if the function is called

--- a/gladney.ts
+++ b/gladney.ts
@@ -999,7 +999,7 @@ export function unionBy<T, U extends Func>(arr: T[][], by: U): T[] {
     result: JSON.stringify(by(i)),
   }))
 
-  const unique = removeDuplicatesBy(asStrings, (i) => JSON.parse(i.result))
+  const unique = uniqueBy(asStrings, (i) => JSON.parse(i.result))
 
   return unique.map((i) => JSON.parse(i.value))
 }
@@ -1163,10 +1163,10 @@ export function insertionSort<T extends string[] | number[]>(arr: T) {
  *
  * Example:
  * ```typescript
- * removeDuplicates([1, 2, 3, 3, 4, 4, 5]) //=> [1, 2, 3, 4, 5]
+ * unique([1, 2, 3, 3, 4, 4, 5]) //=> [1, 2, 3, 4, 5]
  * ```
  **/
-export function removeDuplicates<T>(arr: T[]): T[] {
+export function unique<T>(arr: T[]): T[] {
   if (typeof arr[0] === "object") {
     const strings = arr.map((obj) => JSON.stringify(obj))
     const uniques = new Set(strings)
@@ -1174,10 +1174,7 @@ export function removeDuplicates<T>(arr: T[]): T[] {
   } else return Array.from(new Set(arr))
 }
 
-export function removeDuplicatesBy<T, U extends (arg: T) => any>(
-  arr: T[],
-  callback: U
-) {
+export function uniqueBy<T, U extends (arg: T) => any>(arr: T[], callback: U) {
   const seen: ReturnType<U>[] = []
   return arr.reduce((acc, i) => {
     const result = callback(i)
@@ -1656,7 +1653,7 @@ export function groupByKeyValue<T extends object, U extends keyof T>(
     { id: 4, name: "Dylan" },
 ]
  *
- * removeDuplicatesByKeyValue(members, "id")
+ * uniqueByKeyValue(members, "id")
  * //=>
  * [{ id: 1, name: "Stephen" },
     { id: 2, name: "Andrea" },
@@ -1664,7 +1661,7 @@ export function groupByKeyValue<T extends object, U extends keyof T>(
 ]
  * ```
  */
-export function removeDuplicatesByKeyValue<T extends object, U extends keyof T>(
+export function uniqueByKeyValue<T extends object, U extends keyof T>(
   arr: T[],
   key: U,
   isCaseSensitive = false

--- a/gladney.ts
+++ b/gladney.ts
@@ -2127,6 +2127,30 @@ export function throttle<
   }
 }
 
+/** Returns a function that can only be run a certain number of times
+ *
+ * Example:
+ *
+ * ```typescript
+ * const logHello = () => console.log("hello")
+ * const limitedLogHello = limit(logHello, 1)
+ *
+ * logHello()
+ * logHello()
+ *
+ * //=> "hello"
+ * ```
+ */
+function limit<T extends Func | AsyncFunc>(func: T, limit: number) {
+  let runCount = 0
+  return (...params: Parameters<T>) => {
+    if (runCount < limit) {
+      runCount++
+      func(...params)
+    }
+  }
+}
+
 /** Returns a memoized version of a function.
  *
  * _Memoization is the process of caching a function's result so that if the function is called

--- a/gladney.ts
+++ b/gladney.ts
@@ -512,7 +512,7 @@ export function s(n: number) {
   return n === 1 ? "" : "s"
 }
 
-export function numbers(str: string) {
+export function onlyNumbers(str: string) {
   return String(str).replace(/[^0-9]/g, "")
 }
 
@@ -1379,6 +1379,12 @@ export function reject<T>(arr: T[], fn: Func | AsyncFunc) {
  */
 export function steps(arr: number[]) {
   return arr.slice(1).map((item, i) => item - arr[i])
+}
+
+export function combine<T>(...arrs: T[][]) {
+  return arrs.reduce((acc, arr) => {
+    return acc.concat(arr)
+  }, [])
 }
 
 /** Tranforms an array into an object with keys and values provided via callback function

--- a/gladney.ts
+++ b/gladney.ts
@@ -1343,6 +1343,21 @@ export function swapItems<T>(arr: T[], index1: number, index2: number) {
   })
 }
 
+/** Returns items in an array with a falsy result of a callback function
+ *
+ * Example:
+ *
+ * ```typescript
+ * const arr = [1, 2, 3, 4, 5, 6]
+ * const isEven = (n: number) => n % 2 === 0
+ *
+ * reject(arr, isEven) //=> [1, 3, 5]
+ * ```
+ */
+export function reject<T>(arr: T[], fn: Func | AsyncFunc) {
+  return arr.filter((x) => !fn(x))
+}
+
 /** Tranforms an array into an object with keys and values provided via callback function
  *
  * Example:
@@ -2141,7 +2156,7 @@ export function throttle<
  * //=> "hello"
  * ```
  */
-function limit<T extends Func | AsyncFunc>(func: T, limit: number) {
+export function limit<T extends Func | AsyncFunc>(func: T, limit: number) {
   let runCount = 0
   return (...params: Parameters<T>) => {
     if (runCount < limit) {

--- a/gladney.ts
+++ b/gladney.ts
@@ -1381,10 +1381,28 @@ export function steps(arr: number[]) {
   return arr.slice(1).map((item, i) => item - arr[i])
 }
 
+/** Combines several arrays into one.
+ *
+ * Example:
+ *
+ * ```typescript
+ *  combine([1, 2, 3], [4, 5], [6, 7, 8]) //=> [1, 2, 3, 4, 5, 6, 7, 8]
+ * ```
+ */
 export function combine<T>(...arrs: T[][]) {
   return arrs.reduce((acc, arr) => {
     return acc.concat(arr)
   }, [])
+}
+
+export function join(arr: string[], separator: string, lastSeparator?: string) {
+  return arr.reduce((acc, item, i) => {
+    if (i === 0) return item
+
+    if (i < arr.length - 1) return acc + separator + item
+
+    return lastSeparator ? acc + lastSeparator + item : acc + separator + item
+  }, "")
 }
 
 /** Tranforms an array into an object with keys and values provided via callback function

--- a/gladney.ts
+++ b/gladney.ts
@@ -1451,6 +1451,22 @@ export function join(arr: string[], separator: string, lastSeparator?: string) {
   }, "")
 }
 
+/**
+ * Similar to `Array.find()` but returns the result of the callback function as opposed to the element itself.
+ *
+ * Example:
+ * ```typescript
+ * const callback = (n:number) => n > 2 ? n * n : null
+ *
+ * findValue([1,2,3,4], callback) //=> 9
+ * ```
+ */
+export function findValue<T>(arr: T[], fn: Func<any | Falsy>) {
+  const found = arr.find((item) => !!fn(item))
+
+  return !!found ? fn(found) : null
+}
+
 /** Tranforms an array into an object with keys and values provided via callback function
  *
  * Example:
@@ -2779,9 +2795,9 @@ type StringOrArray<T extends string | any[]> = T extends (infer U)[]
   ? U[]
   : string
 
-type Func = (...args: any) => any
+type Func<T = any, U = any> = (...args: T[]) => U
 
-type AsyncFunc = (...args: any) => Promise<any>
+type AsyncFunc<T = any, U = any> = (...args: T[]) => Promise<U>
 
 type UnwrapPromiseOrResult<T> = T extends (...args: any[]) => Promise<infer U>
   ? U

--- a/gladney.ts
+++ b/gladney.ts
@@ -1365,6 +1365,14 @@ export function reject<T>(arr: T[], fn: Func | AsyncFunc) {
   return arr.filter((x) => !fn(x))
 }
 
+/** Returns an array of the difference of each consecutive item in an array of numbers
+ *
+ * Example:
+ * ```typescript
+ * steps([1, 3, 2, 5, -1]) //=> [2, -1, 3, -6]
+ * ```
+ *
+ */
 export function steps(arr: number[]) {
   return arr.slice(1).map((item, i) => item - arr[i])
 }
@@ -2177,19 +2185,23 @@ export function limit<T extends Func | AsyncFunc>(func: T, limit: number) {
   }
 }
 
+/** Attempts to run a function succesfully up to a specified number of times
+ *
+ */
 export async function retry<T extends Func | AsyncFunc>(
   func: T,
   attempts: number,
-  delay: number
+  delay: number,
+  onFailure?: Func | AsyncFunc
 ) {
   for (let i = 1; i <= attempts; i++) {
     try {
-      await func()
-      break
+      return await func()
     } catch {
       await pause(delay)
     }
   }
+  if (onFailure) return onFailure()
 }
 
 /** Returns a memoized version of a function.

--- a/gladney.ts
+++ b/gladney.ts
@@ -2185,23 +2185,24 @@ export function limit<T extends Func | AsyncFunc>(func: T, limit: number) {
   }
 }
 
-/** Attempts to run a function succesfully up to a specified number of times
+/** Attempts to run a function up to a specified number of times and returns the result if successful. Also accepts a
+ * delay in ms between each attempt and optional fallback function if all calls are unsuccessful.
  *
  */
 export async function retry<T extends Func | AsyncFunc>(
   func: T,
   attempts: number,
-  delay: number,
-  onFailure?: Func | AsyncFunc
+  delay?: number,
+  fallbackFn?: Func | AsyncFunc
 ) {
   for (let i = 1; i <= attempts; i++) {
     try {
       return await func()
     } catch {
-      await pause(delay)
+      await pause(delay ?? 0)
     }
   }
-  if (onFailure) return onFailure()
+  if (fallbackFn) return fallbackFn()
 }
 
 /** Returns a memoized version of a function.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "gladknee",
-      "version": "1.8.3",
+      "version": "1.13.1",
       "license": "ISC",
       "devDependencies": {
         "@types/express": "^4.17.17",
@@ -14,7 +14,7 @@
         "@types/node": "^18.16.3",
         "jest": "^29.5.0",
         "ts-jest": "^29.1.0",
-        "typescript": "^5.5.2"
+        "typescript": "^5.6.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3480,9 +3480,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
-      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gladknee",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "A zero-dependency utility library written in TypeScript",
   "main": "dist/gladney.js",
   "types": "dist/gladney.d.ts",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "@types/node": "^18.16.3",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
-    "typescript": "^5.5.2"
+    "typescript": "^5.6.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gladknee",
-  "version": "1.13.2",
+  "version": "1.14.1",
   "description": "A zero-dependency utility library written in TypeScript",
   "main": "dist/gladney.js",
   "types": "dist/gladney.d.ts",


### PR DESCRIPTION
Add functions:
- `limit` - Returns a version of a function that can only be run X times 
- `digits` - Returns the digits of a number as an array 
- `steps` - Returns the difference between each item in an array and its predecessor
- `retry` - Attempts to run a function X times with optional delay between attempts and optional fallback callback
- `combine`- Combines multiple arrays into one array
- `join`- Combines multiple strings into one string with specified separators, including a specific last separator
- `startsWith` - Returns a boolean of whether or not a string ends with a specific prefix or one of many prefixes
- `endsWith` - Returns a boolean of whether or not a string ends with a specific suffix or one of many suffices
- `putNew` Returns an object with a new key value pair added if the key does not already exist
-  `findValue` Like Array.find() but returns the result of the callback instead of the element itself

Changes:
- Rename `removeDuplicates` -> `unique`
- Rename `removeDuplicatesBy` -> `uniqueBy`