### PR TITLE
v1.17.2 - Fix common() bug

### DIFF
--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -22,25 +22,6 @@ describe("numbers", () => {
     })
   })
 
-  describe("leadingZero", () => {
-    it("returns a single digit with a leading zero by default", () => {
-      expect(_.leadingZero(9)).toBe("09")
-    })
-
-    it("accepts custom zero counts (9, 2)", () => {
-      expect(_.leadingZero(9, 2)).toBe("009")
-    })
-
-    it("accepts custom zero counts (99, 2)", () => {
-      expect(_.leadingZero(99, 2)).toBe("099")
-    })
-
-    it("returns a number with additional digits as a string", () => {
-      expect(_.leadingZero(29)).toBe("29")
-      expect(_.leadingZero(109, 2)).toBe("109")
-    })
-  })
-
   describe("range", () => {
     it("returns a range of numbers", () => {
       expect(_.range(1, 5)).toEqual([1, 2, 3, 4, 5])

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -848,6 +848,13 @@ describe("arrays", () => {
       const arr3 = [2, 5, 7, 8]
       expect(_.common(arr, arr2, arr3)).toEqual([2, 3, 5])
     })
+
+    it("does not return duplicates in one array", () => {
+      const arr = [1, 1, 3, 4]
+      const arr2 = [2, 3, 5]
+
+      expect(_.common(arr, arr2).includes(1)).toBe(false)
+    })
   })
 
   describe("count", () => {

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -1218,6 +1218,14 @@ describe("objects", () => {
     })
   })
 
+  describe("getIn", () => {
+    it("returns the last key value", () => {
+      const obj = { a: { b: { c: 42 } } }
+      expect(_.getIn(obj, ["a", "b"])).toEqual({ c: 42 })
+      expect(_.getIn(obj, ["a", "b", "c"])).toBe(42)
+    })
+  })
+
   describe("sortByKeyValues", () => {
     it("returns the array sorted by key values (all asc)", () => {
       const arr = [

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -674,6 +674,20 @@ describe("arrays", () => {
     })
   })
 
+  describe("zip", () => {
+    it("returns tuples of combined elements", () => {
+      const arr = [1, 2, 3]
+      const arr2 = ["a", "b", "c"]
+      const arr3 = ["alpha", "beta", "chi"]
+
+      expect(_.zip(arr, arr2, arr3)).toEqual([
+        [1, "a", "alpha"],
+        [2, "b", "beta"],
+        [3, "c", "chi"],
+      ])
+    })
+  })
+
   describe("shuffle", () => {
     it("returns the array in a different order", () => {
       const arr = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]

--- a/gladney.spec.ts
+++ b/gladney.spec.ts
@@ -1555,38 +1555,6 @@ describe("misc", () => {
     })
   })
 
-  describe("caseEquals", () => {
-    it("returns a corresponding expression if a match is found", () => {
-      const widthByHeight = _.round(1920 / 1080, 0.01)
-
-      const ratio = _.caseEquals(
-        widthByHeight,
-        [1.78, "16:9"],
-        [1.5, "3:2"],
-        [1.33, "4:3"],
-        [1, "1:1"],
-        "Uncommon aspect ratio"
-      )
-
-      expect(ratio).toBe("16:9")
-    })
-
-    it("returns the default express if no match is found", () => {
-      const widthByHeight = _.round(2200 / 1080, 0.01)
-
-      const ratio = _.caseEquals(
-        widthByHeight,
-        [1.78, "16:9"],
-        [1.5, "3:2"],
-        [1.33, "4:3"],
-        [1, "1:1"],
-        "Uncommon aspect ratio"
-      )
-
-      expect(ratio).toBe("Uncommon aspect ratio")
-    })
-  })
-
   describe("objectToQueryParams", () => {
     it("converts an object to string of query params", () => {
       const obj = { name: "john", age: 30 }

--- a/gladney.ts
+++ b/gladney.ts
@@ -67,22 +67,6 @@ export function clampNumber(
   return result
 }
 
-/** Adds a specified number of leading zeros to a number. Default is 1.
- *
- * _Example:_
- * ```typescript
- * leadingZero(9) //=> "09"
- *
- * leadingZero(9, 2) //=> "009"
- * ```
- **/
-export function leadingZero(n: number, zeros = 1) {
-  if (String(n).length > zeros) return String(n)
-  const digitCount = zeros + 1
-  const z = Array(digitCount).fill("0").join("")
-  return String(`${z}${n}`).slice(-1 * digitCount)
-}
-
 /** Returns an array of numbers, starting from and ending at provided numbers.
  * You can optionally pass in a step number to increment by a number other than 1. You can also increment negatively.
  *

--- a/gladney.ts
+++ b/gladney.ts
@@ -2814,38 +2814,6 @@ export function stripHTML(text: string) {
   return result
 }
 
-/**
- * Returns a corresponding expression based on a matching value of an expression provided. Uses
- * `isEqual` under the hood.
- *
- * Example:
- * ```typescript
- * const widthByHeight = round(1920 / 1080, 0.01) // 1.78
- *
- * const apectRatio = caseEquals(
- *   widthByHeight,
- *   [1.78, "16:9"],
- *   [1.5, "3:2"],
- *   [1.33, "4:3"],
- *   [1, "1:1"],
- *   "Uncommon aspect ratio"
- * )
- * //=> "16:9"
- */
-
-export function caseEquals<T = any, U = any>(
-  value: T,
-  ...casesAndDefault: [...c: [T, U][], U]
-) {
-  for (let i = 0; i < casesAndDefault.length; i++) {
-    const currentCase = casesAndDefault[i]
-    if (Array.isArray(currentCase) && value === currentCase[0]) {
-      return currentCase[1]
-    }
-  }
-  return casesAndDefault[casesAndDefault.length - 1]
-}
-
 const defaultMatchOptions: MatchOptions = {
   ignoreCase: false,
   ignoreSpace: false,

--- a/gladney.ts
+++ b/gladney.ts
@@ -1340,9 +1340,10 @@ export function uncommon<T>(firstArray: T[], ...otherArrays: T[][]) {
  * See also: `difference()` and `intersection()`
  **/
 export function common<T>(firstArray: T[], ...otherArrays: T[][]) {
-  const arraysAsJSONStrings = [firstArray, ...otherArrays].map((arr) =>
-    arr.map((item: T) => JSON.stringify(item))
-  )
+  let arraysAsJSONStrings = [firstArray, ...otherArrays]
+    .map((arr) => arr.map((item: T) => JSON.stringify(item)))
+    .map((arr) => unique(arr))
+
   const seen: string[] = []
   let result: string[] = []
 

--- a/gladney.ts
+++ b/gladney.ts
@@ -1712,7 +1712,6 @@ export function objectInto<T extends object, K extends keyof T, V extends T[K]>(
     {}
   )
 }
-
 /** Returns the sum of the values of a specific shared key in an array of objects.
  *
  * Example:
@@ -1765,6 +1764,29 @@ export function sortByKeyValue<T extends object, U extends keyof T>(
   return [...arr].sort((a, b) =>
     a[key] < b[key] ? (isAscending ? -1 : 1) : isAscending ? 1 : -1
   )
+}
+
+/** Returns the value of a nested key within an object of objects.
+ * 
+ * Example:
+ * ```typescript
+ * const nestedObject = { a: { b: { c: 42 } } }
+ * getIn(nestedObject, ["a", "b", "c"]) //=> 42
+ * ```
+ * 
+ 
+ */
+export function getIn<T extends object>(
+  o: T,
+  nestedKeys: [string, string, ...rest: string[]]
+) {
+  const recursiveGet = (obj: any, key: any, i: number): any => {
+    return i == nestedKeys.length - 1
+      ? obj[nestedKeys[i]]
+      : recursiveGet(obj[key], nestedKeys[i + 1], i + 1)
+  }
+
+  return recursiveGet(o, nestedKeys[0], 0)
 }
 
 /** Returns an array of objects with nested sorting based on a set of specific shared keys. Optionally

--- a/gladney.ts
+++ b/gladney.ts
@@ -1573,9 +1573,9 @@ export function join(arr: string[], separator: string, lastSeparator?: string) {
  *
  * Example:
  * ```typescript
- * const callback = (n:number) => n > 2 ? n * n : null
+ * const squareGreaterThan2 = (n:number) => n > 2 ? n * n : null
  *
- * findValue([1,2,3,4], callback) //=> 9
+ * findValue([1, 2, 3, 4], squareGreaterThan2) //=> 9
  * ```
  */
 export function findValue<T>(arr: T[], fn: Func<any | Falsy>) {
@@ -1600,6 +1600,26 @@ export function arrayInto<T extends any[]>(
   return arr.reduce((acc, i, index) => ({ ...acc, ...fn(i, index) }), {})
 }
 
+/** Combines corresponding elements from a collection of arrays into an array of tuples
+ *
+ * Example:
+ * ```typescript
+ * zip([1, 2, 3], ["a", "b", "c"]) //=> [[1, "a"], [2, "b"], [3, "c"]]
+ * ```
+ *
+ */
+export function zip(arr: any[], ...rest: any[][]) {
+  const result = []
+  for (let i = 0; i < arr.length; i++) {
+    const current = [arr[i]]
+
+    for (let j = 0; j < rest.length; j++) {
+      current.push(rest[j][i])
+    }
+    result.push(current)
+  }
+  return result
+}
 /** Returns a boolean indicating whether or not the array includes the object
  *
  * Example:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gladknee",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "A zero-dependency utility library written in TypeScript",
   "main": "dist/gladney.js",
   "types": "dist/gladney.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gladknee",
-  "version": "1.16.2",
+  "version": "1.17.1",
   "description": "A zero-dependency utility library written in TypeScript",
   "main": "dist/gladney.js",
   "types": "dist/gladney.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gladknee",
-  "version": "1.17.1",
+  "version": "1.17.2",
   "description": "A zero-dependency utility library written in TypeScript",
   "main": "dist/gladney.js",
   "types": "dist/gladney.d.ts",


### PR DESCRIPTION
This PR fixes a bug where the common() function would return an item that appears more than once in one array but not in at least two arrays.